### PR TITLE
Remove setproctitle as dependency and add telemetry test to runnable

### DIFF
--- a/build.py
+++ b/build.py
@@ -147,7 +147,8 @@ def unit_test():
     """
     utility.exec_command(
         'pytest --cov mssqlcli tests/test_mssqlcliclient.py tests/test_main.py tests/test_fuzzy_completion.py '
-        'tests/test_rowlimit.py tests/test_sqlcompletion.py tests/test_prioritization.py mssqlcli/jsonrpc/contracts/tests',
+        'tests/test_rowlimit.py tests/test_sqlcompletion.py tests/test_prioritization.py mssqlcli/jsonrpc/contracts/tests '
+        'tests/test_telemetry.py',
         utility.ROOT_DIR,
         continue_on_error=False)
 

--- a/dev_setup.py
+++ b/dev_setup.py
@@ -8,10 +8,6 @@ print('Root directory \'{}\'\n'.format(utility.ROOT_DIR))
 # install general requirements.
 utility.exec_command('pip install -r requirements-dev.txt', utility.ROOT_DIR)
 
-platform = utility.get_current_platform()
-if platform != 'win32' and platform != 'win_amd64':
-    utility.exec_command('pip install setproctitle>=1.1.9', utility.ROOT_DIR)
-
 # install mssqltoolsservice if this platform supports it.
 utility.copy_current_platform_mssqltoolsservice()
 

--- a/setup.py
+++ b/setup.py
@@ -46,14 +46,6 @@ install_requirements = [
     'enum34>=1.1.6'
 ]
 
-# setproctitle is used to mask the password when running `ps` in command line.
-# But this is not necessary in Windows since the password is never shown in the
-# task manager. Also setproctitle is a hard dependency to install in Windows,
-# so we'll only install it if we're not in Windows.
-if platform.system() != 'Windows' and not platform.system().startswith("CYGWIN"):
-    install_requirements.append('setproctitle >= 1.1.9')
-
-
 setup(
     name='mssql-cli',
     author='Microsoft Corporation',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,53 +1,12 @@
 # coding=utf-8
 from __future__ import unicode_literals
 import os
-import platform
 from mssqlutils import create_mssql_cli_client, shutdown, run_and_return_string_from_formatter
 from time import sleep
-
 import pytest
-try:
-    import setproctitle
-except ImportError:
-    setproctitle = None
-
 from mssqlcli.main import (
-    obfuscate_process_password, format_output, MssqlCli, OutputSettings
+    format_output, MssqlCli, OutputSettings
 )
-
-
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='Not applicable in windows')
-@pytest.mark.skipif(not setproctitle,
-                    reason='setproctitle not available')
-def test_obfuscate_process_password():
-    original_title = setproctitle.getproctitle()
-
-    setproctitle.setproctitle("mssql-cli user=root password=secret host=localhost")
-    obfuscate_process_password()
-    title = setproctitle.getproctitle()
-    expected = "mssql-cli user=root password=xxxx host=localhost"
-    assert title == expected
-
-    setproctitle.setproctitle("mssql-cli user=root password=top secret host=localhost")
-    obfuscate_process_password()
-    title = setproctitle.getproctitle()
-    expected = "mssql-cli user=root password=xxxx host=localhost"
-    assert title == expected
-
-    setproctitle.setproctitle("mssql-cli user=root password=top secret")
-    obfuscate_process_password()
-    title = setproctitle.getproctitle()
-    expected = "mssql-cli user=root password=xxxx"
-    assert title == expected
-
-    setproctitle.setproctitle("mssql-cli postgres://root:secret@localhost/db")
-    obfuscate_process_password()
-    title = setproctitle.getproctitle()
-    expected = "mssql-cli postgres://root:xxxx@localhost/db"
-    assert title == expected
-
-    setproctitle.setproctitle(original_title)
 
 
 def test_format_output():


### PR DESCRIPTION
setproctitle is never used as unlike pgcli we do not allow users to pass in the password in the url format for the database.