### PR TITLE
Adding quotes to completions and suppressing exceptions.

### DIFF
--- a/mssqlcli/completion_refresher.py
+++ b/mssqlcli/completion_refresher.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+import mssqlcli.decorators as decorators
 
 from collections import OrderedDict
 from .mssqlcompleter import MssqlCompleter
@@ -91,11 +92,13 @@ def refresher(name, refreshers=CompletionRefresher.refreshers):
 
 
 @refresher('schemata')
+@decorators.suppress_all_exceptions()
 def refresh_schemata(completer, mssqlcliclient):
     completer.extend_schemata(mssqlcliclient.schemas())
 
 
 @refresher('tables')
+@decorators.suppress_all_exceptions()
 def refresh_tables(completer, mssqlcliclient):
     completer.extend_relations(mssqlcliclient.tables(), kind='tables')
     completer.extend_columns(mssqlcliclient.table_columns(), kind='tables')
@@ -103,16 +106,19 @@ def refresh_tables(completer, mssqlcliclient):
 
 
 @refresher('views')
+@decorators.suppress_all_exceptions()
 def refresh_views(completer, mssqlcliclient):
     completer.extend_relations(mssqlcliclient.views(), kind='views')
     completer.extend_columns(mssqlcliclient.view_columns(), kind='views')
 
 
 @refresher('databases')
+@decorators.suppress_all_exceptions()
 def refresh_databases(completer, mssqlcliclient):
     completer.extend_database_names(mssqlcliclient.databases())
 
 
 @refresher('types')
+@decorators.suppress_all_exceptions()
 def refresh_types(completer, mssqlcliclient):
     completer.extend_datatypes(mssqlcliclient.user_defined_types())

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -112,9 +112,7 @@ class MssqlCompleter(Completer):
         self.all_completions = set(self.keywords + self.functions)
 
     def escape_name(self, name):
-        if name and ((not self.name_pattern.match(name))
-                or (name.upper() in self.reserved_words)
-                or (name.upper() in self.functions)):
+        if name:
             name = '"%s"' % name
 
         return name


### PR DESCRIPTION
Currently when quitting, there is a intermittent message that may arise:
NoneType is not iterable.

This steams from the completion refresher receiving nothing from sqltoolsservice which makes sense since we are killing the process. Suppressing this so it doesn't pollute the prompt.