### PR TITLE
Combine the expanded output and auto expand options in config.

### DIFF
--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -135,9 +135,8 @@ class MssqlCli(object):
         self.multi_line = c['main'].as_bool('multi_line')
         self.multiline_mode = c['main'].get('multi_line_mode', 'tsql')
         self.vi_mode = c['main'].as_bool('vi')
-        self.auto_expand = auto_vertical_output or c['main'].as_bool(
-            'auto_expand')
-        self.expanded_output = c['main'].as_bool('expand')
+        self.auto_expand = auto_vertical_output or c['main']['expand'] == 'auto'
+        self.expanded_output = c['main']['expand'] == 'always'
         if row_limit is not None:
             self.row_limit = row_limit
         else:

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -18,11 +18,11 @@ multi_line = False
 # a command.
 multi_line_mode = tsql
 
-# Enables expand mode.
-expand = False
-
-# Enables auto expand mode.
-auto_expand = False
+# Use expand mode to display the results.
+# Possible values: "always", "never" and "auto"
+# "auto" will switch to expanded mode automatically if the table is too wide to
+# fit the screen.
+expand = auto
 
 # If set to True, table suggestions will include a table alias
 generate_aliases = False


### PR DESCRIPTION
This combines two separate options in the config file into a single one. 

Be aware this does change the default behavior of the output. The expanded mode is now set to auto, meaning if the table is too wide to fit the screen then the output will be shown using the vertical mode instead of the tabular mode. 