### PR TITLE
Bash script: Use specific Python interpreter

### DIFF
--- a/mssql-cli
+++ b/mssql-cli
@@ -13,4 +13,12 @@ if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi
 
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 
-python -m mssqlcli.main "$@"
+# Usually, this script is installed by setuptools right next to a Python interpreter.
+# In case of using virtualenvs, it's essential to use that one instead of the one
+# that's first in $PATH, so we do not accidentally end up using the wrong packages.
+if [[ -x ${DIR}/python ]] ; then
+    ${DIR}/python -m mssqlcli.main "$@"
+else
+    # Use the default interpreter as fallback.
+    python -m mssqlcli.main "$@"
+fi


### PR DESCRIPTION
This fixes an issue when the `python` interpreter that's first in `$PATH` is *not* the one that is using the `site-packages` where `mssql-cli` is installed.

This is especially an issue in an environment where there are lots of different virtualenvs in `$PATH` (i.e. when using a separate virtualenv per installed application) and the one where `mssql-cli` is installed is not the first one, so the wrong interpreter would be used.

Actually, since the script should always be installed next to an interpreter executable, the `else` part should not be neccessary, but I've kept it for backwards compatibility with strange other setups.

This is not fixing it for Windows, but since I don't have a Windows machine for testing and think fixing it on one system is better than on none, I'm still doing this pull request.

Note: This whole issue could be fixed by using `entry_points` instead of `scripts`, but it seems like you need to set `PYTHONIOENCODING` before running the interpreter, so that's not a choice unfortunately.
  