### PR TITLE
Adding TRANSFER keyword and fixing smart completion flag.

### DIFF
--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -167,10 +167,6 @@ class MssqlCli(object):
 
         self.query_history = []
 
-        # Initialize completer
-        # Smart completion is not-supported in Public Preview. Tracked by
-        # GitHub issue number 47.
-        smart_completion = False
         keyword_casing = c['main']['keyword_casing']
         self.settings = {
             'casing_file': get_casing_file(c),
@@ -185,7 +181,7 @@ class MssqlCli(object):
             'keyword_casing': keyword_casing,
         }
 
-        completer = MssqlCompleter(smart_completion, settings=self.settings)
+        completer = MssqlCompleter(settings=self.settings)
 
         self.completer = completer
         self._completer_lock = threading.Lock()

--- a/mssqlcli/packages/mssqlliterals/sqlliterals.json
+++ b/mssqlcli/packages/mssqlliterals/sqlliterals.json
@@ -335,6 +335,7 @@
     "TO": [],
     "TOP": [],
     "TRAN": [],
+    "TRANSFER": [],
     "TRANSACTION": [],
     "TRIGGER": [],
     "TRUNCATE": [],


### PR DESCRIPTION
Even though we set smart completion to off, it has always been turned back on by the background completion refresher thread. This allowed us to select columns from the current table we are targeting.

This PR removes the initial turn off of smart completion and use default value of true.

Another issue was when typing "Alter Schema xxx" The TRANSFER keyword was not populated. Following the current convention which populates all keywords when the last word before the cursor is a identifier, we will populate the transfer keyword too. We can refactor this when we fine tune smart completion, but this should unblock the current customer experience reported here: #114 