### PR TITLE
Add prompt format as config and CLI option.

### DIFF
--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -98,6 +98,7 @@ Microsoft Privacy statement: https://privacy.microsoft.com/en-us/privacystatemen
 class MssqlCli(object):
 
     max_len_prompt = 30
+    default_prompt = '\\d> '
 
     def set_default_pager(self, config):
         configured_pager = config['main'].get('pager')
@@ -125,7 +126,8 @@ class MssqlCli(object):
                  mssqlclirc_file=None, row_limit=None,
                  single_connection=False, less_chatty=None,
                  auto_vertical_output=False, sql_tools_client=None,
-                 integrated_auth=False, enable_sqltoolsservice_logging=False):
+                 integrated_auth=False, enable_sqltoolsservice_logging=False,
+                 prompt=None):
 
         self.force_passwd_prompt = force_passwd_prompt
 
@@ -143,6 +145,7 @@ class MssqlCli(object):
         self.vi_mode = c['main'].as_bool('vi')
         self.auto_expand = auto_vertical_output or c['main']['expand'] == 'auto'
         self.expanded_output = c['main']['expand'] == 'always'
+        self.prompt_format = prompt or c['main'].get('prompt', self.default_prompt)
         if row_limit is not None:
             self.row_limit = row_limit
         else:
@@ -435,7 +438,7 @@ class MssqlCli(object):
             set_vi_mode_enabled=set_vi_mode)
 
         def prompt_tokens(_):
-            prompt = self.get_prompt()
+            prompt = self.get_prompt(self.prompt_format)
             return [(Token.Prompt, prompt)]
 
         def get_continuation_tokens(cli, width):
@@ -648,9 +651,14 @@ class MssqlCli(object):
             return self.completer.get_completions(
                 Document(text=text, cursor_position=cursor_positition), None)
 
-    def get_prompt(self):
+    def get_prompt(self, string):
         # mssql-cli
-        string = self.mssqlcliclient_query_execution.database + u'>'
+        string = string.replace('\\t', self.now.strftime('%x %X'))
+        string = string.replace('\\u', self.mssqlcliclient_query_execution.user_name or '(none)')
+        string = string.replace('\\h', self.mssqlcliclient_query_execution.host or '(none)')
+        string = string.replace('\\d', self.mssqlcliclient_query_execution.database or '(none)')
+        string = string.replace('\\p', str(self.mssqlcliclient_query_execution.port) or '(none)')
+        string = string.replace('\\n', "\n")
         return string
 
     def get_last_query(self):
@@ -698,9 +706,10 @@ class MssqlCli(object):
 @click.option('--enable-sqltoolsservice-logging', is_flag=True,
               default=False,
               help='Enables diagnostic logging for the SqlToolsService.')
+@click.option('--prompt', help='Prompt format (Default: "\\d> ").')
 def cli(username, server, prompt_passwd, database, version, mssqlclirc, row_limit, less_chatty, auto_vertical_output,
         integrated_auth, encrypt, trust_server_certificate, connect_timeout, application_intent, multi_subnet_failover,
-        packet_size, enable_sqltoolsservice_logging, dac_connection):
+        packet_size, enable_sqltoolsservice_logging, dac_connection, prompt):
 
     if version:
         print('Version:', __version__)
@@ -718,7 +727,7 @@ def cli(username, server, prompt_passwd, database, version, mssqlclirc, row_limi
     if dac_connection and server and not server.lower().startswith("admin:"):
         server = "admin:" + server
 
-    mssqlcli = MssqlCli(prompt_passwd, row_limit=row_limit, single_connection=False,
+    mssqlcli = MssqlCli(force_passwd_prompt=prompt_passwd, prompt=prompt, row_limit=row_limit, single_connection=False,
                         mssqlclirc_file=mssqlclirc, less_chatty=less_chatty, auto_vertical_output=auto_vertical_output,
                         integrated_auth=integrated_auth, enable_sqltoolsservice_logging=enable_sqltoolsservice_logging)
 

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -655,9 +655,9 @@ class MssqlCli(object):
         # mssql-cli
         string = string.replace('\\t', self.now.strftime('%x %X'))
         string = string.replace('\\u', self.mssqlcliclient_query_execution.user_name or '(none)')
-        string = string.replace('\\h', self.mssqlcliclient_query_execution.host or '(none)')
+        string = string.replace('\\h', self.mssqlcliclient_query_execution.prompt_host or '(none)')
         string = string.replace('\\d', self.mssqlcliclient_query_execution.database or '(none)')
-        string = string.replace('\\p', str(self.mssqlcliclient_query_execution.port) or '(none)')
+        string = string.replace('\\p', str(self.mssqlcliclient_query_execution.prompt_port) or '(none)')
         string = string.replace('\\n', "\n")
         return string
 
@@ -706,7 +706,7 @@ class MssqlCli(object):
 @click.option('--enable-sqltoolsservice-logging', is_flag=True,
               default=False,
               help='Enables diagnostic logging for the SqlToolsService.')
-@click.option('--prompt', help='Prompt format (Default: "\\d> ").')
+@click.option('--prompt', help='Prompt format (Default: "{}").'.format(MssqlCli.default_prompt))
 def cli(username, server, prompt_passwd, database, version, mssqlclirc, row_limit, less_chatty, auto_vertical_output,
         integrated_auth, encrypt, trust_server_certificate, connect_timeout, application_intent, multi_subnet_failover,
         packet_size, enable_sqltoolsservice_logging, dac_connection, prompt):

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -1,5 +1,5 @@
+import getpass
 import logging
-import os
 import time
 import uuid
 from time import sleep
@@ -34,7 +34,7 @@ class MssqlCliClient(object):
             self.prompt_host = server_name
             self.prompt_port = 1433
         if authentication_type == u'Integrated':
-            self.user_name = os.getlogin()
+            self.user_name = getpass.getuser()
         else:
             self.user_name = user_name
         self.password = password

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -24,7 +24,13 @@ class MssqlCliClient(object):
                  authentication_type=u'SqlLogin', database=u'master', owner_uri=None, multiple_active_result_sets=True,
                  encrypt=None, trust_server_certificate=None, connection_timeout=None, application_intent=None,
                  multi_subnet_failover=None, packet_size=None, **kwargs):
+
         self.server_name = server_name
+        if ',' in server_name:
+            self.host, self.port = self.server_name.split(',')
+        else:
+            self.host = server_name
+            self.port = 1433
         self.user_name = user_name
         self.password = password
         self.authentication_type = authentication_type

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -1,14 +1,16 @@
 import logging
-from time import sleep
+import os
 import time
 import uuid
+from time import sleep
+
 import click
 import sqlparse
 
 from mssqlcli import mssqlqueries
 from mssqlcli.jsonrpc.contracts import connectionservice, queryexecutestringservice as queryservice
-from mssqlcli.sqltoolsclient import SqlToolsClient
 from mssqlcli.packages.parseutils.meta import ForeignKey
+from mssqlcli.sqltoolsclient import SqlToolsClient
 
 logger = logging.getLogger(u'mssqlcli.mssqlcliclient')
 time_wait_if_no_response = 0.05
@@ -27,11 +29,14 @@ class MssqlCliClient(object):
 
         self.server_name = server_name
         if ',' in server_name:
-            self.host, self.port = self.server_name.split(',')
+            self.prompt_host, self.prompt_port = self.server_name.split(',')
         else:
-            self.host = server_name
-            self.port = 1433
-        self.user_name = user_name
+            self.prompt_host = server_name
+            self.prompt_port = 1433
+        if authentication_type == u'Integrated':
+            self.user_name = os.getlogin()
+        else:
+            self.user_name = user_name
         self.password = password
         self.authentication_type = authentication_type
         self.database = database

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -103,7 +103,7 @@ row_limit = 1000
 # Skip intro on startup and goodbye on exit
 less_chatty = False
 
-# mysql-cli prompt
+# mssql-cli prompt
 # \t - Current date and time
 # \u - Username
 # \h - Hostname of the server

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -103,6 +103,15 @@ row_limit = 1000
 # Skip intro on startup and goodbye on exit
 less_chatty = False
 
+# mysql-cli prompt
+# \t - Current date and time
+# \u - Username
+# \h - Hostname of the server
+# \d - Database name
+# \p - Database port
+# \n - Newline
+prompt = '\d> '
+
 # Number of lines to reserve for the suggestion menu
 min_num_menu_lines = 4
 


### PR DESCRIPTION
Configurable prompt for mssql-cli. I set the default to `"\\d> "` to mimic the current behavior (even though pgcli and mycli have longer default prompts, e.g. `"\\u@\\h:\\d> "`.