### PR TITLE
Ron/build fix

### DIFF
--- a/mssqlcli/jsonrpc/contracts/tests/test_executestring.py
+++ b/mssqlcli/jsonrpc/contracts/tests/test_executestring.py
@@ -57,7 +57,6 @@ class QueryExecuteTests(unittest.TestCase):
             request = queryservice.QueryExecuteStringRequest(
                 2, rpc_client, parameters)
             self.verify_query_response(request=request,
-                                       expected_complete_event=1,
                                        expected_error_count=1)
             rpc_client.shutdown()
 

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -157,12 +157,14 @@ class MssqlCliClient(object):
 
         if query_response.exception_message:
             logger.error(u'Query response had an exception')
-            return self.tabular_results_generator(
+
+            yield self.tabular_results_generator(
                 column_info=None,
                 result_rows=None,
                 query=query,
                 message=query_response.exception_message,
                 is_error=True)
+            return
 
         if (not query_response.batch_summaries[0].result_set_summaries) or \
            (query_response.batch_summaries[0].result_set_summaries[0].row_count == 0):


### PR DESCRIPTION
When the fix for issue #136  was submitted, it used syntax that is not supported on Python <= 3.3. The error in particular is using a return statement within a function that returns a generator. The correct fix is to first yield the message we want to return and then proceed to return from the function call.

The test was also updated because if a query fails, the request finishes on a query error event. Finishing on a error event does not yield a query complete event.

Tests have been rerun and lab runs looked clean.