### PR TITLE
Adding F2 toggle option for smart completion

### DIFF
--- a/mssqlcli/key_bindings.py
+++ b/mssqlcli/key_bindings.py
@@ -22,6 +22,15 @@ def mssqlcli_bindings(get_vi_mode_enabled, set_vi_mode_enabled):
         enable_search=True,
         enable_abort_and_exit_bindings=True)
 
+    @key_binding_manager.registry.add_binding(Keys.F2)
+    def _(event):
+        """
+        Enable/Disable SmartCompletion Mode.
+        """
+        _logger.debug('Detected F2 key.')
+        buf = event.cli.current_buffer
+        buf.completer.smart_completion = not buf.completer.smart_completion
+
     @key_binding_manager.registry.add_binding(Keys.F3)
     def _(event):
         """

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -170,6 +170,8 @@ class MssqlCli(object):
 
         self.query_history = []
 
+        # Initialize completer
+        smart_completion = True if c['main'].get('smart_completion', 'True') == 'True' else False
         keyword_casing = c['main']['keyword_casing']
         self.settings = {
             'casing_file': get_casing_file(c),
@@ -184,7 +186,7 @@ class MssqlCli(object):
             'keyword_casing': keyword_casing,
         }
 
-        completer = MssqlCompleter(settings=self.settings)
+        completer = MssqlCompleter(smart_completion=smart_completion, settings=self.settings)
 
         self.completer = completer
         self._completer_lock = threading.Lock()

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -1,6 +1,10 @@
 # vi: ft=dosini
 [main]
 
+# Enables context sensitive auto-completion. If this is disabled the all
+# possible completions will be listed.
+smart_completion = True
+
 # Display the completions in several columns. (More completions will be
 # visible.)
 wider_completion_menu = False

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -426,15 +426,12 @@ class MssqlCompleter(Completer):
         if smart_completion is None:
             smart_completion = self.smart_completion
 
-        # If smart_completion is off then match any word that starts with
-        # 'word_before_cursor'.
-        if not smart_completion:
-            matches = self.find_matches(word_before_cursor, self.all_completions,
-                                        mode='strict')
-            completions = [m.completion for m in matches]
-            return sorted(completions, key=operator.attrgetter('text'))
-
+        # If smart_completion is off then return nothing.
+        # Our notion of smart completion is all or none unlike PGCLI and MyCLI.
         matches = []
+        if not smart_completion:
+            return matches
+
         suggestions = suggest_type(document.text, document.text_before_cursor)
 
         for suggestion in suggestions:

--- a/mssqlcli/mssqltoolbar.py
+++ b/mssqlcli/mssqltoolbar.py
@@ -25,6 +25,11 @@ def create_toolbar_tokens_func(get_vi_mode_enabled, get_is_refreshing,
         result = []
         result.append((token, ' '))
 
+        if cli.buffers[DEFAULT_BUFFER].completer.smart_completion:
+            result.append((token.On, '[F2] Smart Completion: ON  '))
+        else:
+            result.append((token.Off, '[F2] Smart Completion: OFF  '))
+
         if cli.buffers[DEFAULT_BUFFER].always_multiline:
             result.append((token.On, '[F3] Multiline: ON  '))
         else:


### PR DESCRIPTION
Enhancement for #158.

Smart completion is all or none now, there is no notion of naive completion which only recommends keywords when smart completion is off.

Smart completion is toggled via F2.

Config file contains smart completion flag, which if not present defaults to True.