### PR TITLE
Fixing missing regex for new special command for named query.

### DIFF
--- a/mssqlcli/packages/sqlcompletion.py
+++ b/mssqlcli/packages/sqlcompletion.py
@@ -157,7 +157,7 @@ def suggest_type(full_text, text_before_cursor):
     return suggest_based_on_last_token(stmt.last_token, stmt)
 
 
-named_query_regex = re.compile(r'^\s*\\ns\s+[A-z0-9\-_]+\s+')
+named_query_regex = re.compile(r'^\s*\\sn\s+[A-z0-9\-_]+\s+')
 
 
 def _strip_named_query(txt):
@@ -284,7 +284,7 @@ def suggest_special(text):
                 return (Schema(), Function(schema=None, usage='special'),)
             return (Schema(), rel_type(schema=None))
 
-    if cmd in ['\\n', '\\ns', '\\nd']:
+    if cmd in ['\\n', '\\sn', '\\dn']:
         return (NamedQuery(),)
 
     return (Keyword(), Special())


### PR DESCRIPTION
Schema's were not suggested after a named query special command was used. This was due to the named query regex and smart completion not updating for the new \\sn command rather than the \\ns.