### PR TITLE
Fix: Connection did not succeed. Error message: Connection request encountered an exception

### DIFF
--- a/mssqlcli/jsonrpc/contracts/connectionservice.py
+++ b/mssqlcli/jsonrpc/contracts/connectionservice.py
@@ -31,7 +31,7 @@ class ConnectionRequest(Request):
             response = self.json_rpc_client.get_response(self.id, self.owner_uri)
             decoded_response = None
             if response:
-                logger.info(response)
+                logger.debug(response)
                 decoded_response = self.decode_response(response)
 
             if isinstance(decoded_response, ConnectionCompleteEvent):
@@ -42,7 +42,7 @@ class ConnectionRequest(Request):
             return decoded_response
 
         except Exception as error:
-            logger.info(str(error))
+            logger.debug(str(error))
             self.finished = True
             self.json_rpc_client.request_finished(self.id)
             self.json_rpc_client.request_finished(self.owner_uri)

--- a/mssqlcli/jsonrpc/contracts/connectionservice.py
+++ b/mssqlcli/jsonrpc/contracts/connectionservice.py
@@ -31,7 +31,7 @@ class ConnectionRequest(Request):
             response = self.json_rpc_client.get_response(self.id, self.owner_uri)
             decoded_response = None
             if response:
-                logger.debug(response)
+                logger.info(response)
                 decoded_response = self.decode_response(response)
 
             if isinstance(decoded_response, ConnectionCompleteEvent):
@@ -42,7 +42,7 @@ class ConnectionRequest(Request):
             return decoded_response
 
         except Exception as error:
-            logger.debug(str(error))
+            logger.info(str(error))
             self.finished = True
             self.json_rpc_client.request_finished(self.id)
             self.json_rpc_client.request_finished(self.owner_uri)
@@ -70,7 +70,7 @@ class ConnectionRequest(Request):
         if u'result' in obj:
             return ConnectionResponse(obj)
 
-        elif u'params' in obj:
+        elif 'method' in obj and obj['method'] == 'connection/complete':
             return ConnectionCompleteEvent(obj)
 
         # Could not decode return st


### PR DESCRIPTION
Connection service would process responses by looking for the key 'params' in the JSON RPC response. This was not narrow enough and almost every response contains that value. It seems like we missed the explicit check for the method name compared to query execution service.

This issue arises when we would switch between databases 3 times.
