### PR TITLE
Removing redundant method in connection service.

### DIFF
--- a/mssqlcli/completion_refresher.py
+++ b/mssqlcli/completion_refresher.py
@@ -51,10 +51,12 @@ class CompletionRefresher(object):
         completer = MssqlCompleter(smart_completion=True, settings=settings)
 
         executor = mssqlcliclient
-        if not executor.connect():
+        owner_uri, error_messages = executor.connect()
+
+        if not owner_uri:
             # If we were unable to connect, do not break the experience for the user.
             # Return nothing, smart completion can maintain the keywords and functions completions.
-            logger.error(u'Completion Refresher failed to connect to the target server.')
+            logger.error(u'Completion refresher connection failure.'.join(error_messages))
             return
         # If callbacks is a single function then push it into a list.
         if callable(callbacks):

--- a/mssqlcli/jsonrpc/contracts/connectionservice.py
+++ b/mssqlcli/jsonrpc/contracts/connectionservice.py
@@ -1,6 +1,5 @@
 from mssqlcli.jsonrpc.contracts import Request
 
-import sys
 import logging
 
 logger = logging.getLogger(u'mssqlcli.connectionservice')
@@ -42,7 +41,7 @@ class ConnectionRequest(Request):
             return decoded_response
 
         except Exception as error:
-            logger.debug(str(error))
+            logger.info(str(error))
             self.finished = True
             self.json_rpc_client.request_finished(self.id)
             self.json_rpc_client.request_finished(self.owner_uri)
@@ -144,38 +143,3 @@ class ConnectionResponse(object):
     def __init__(self, params):
         self.result = params[u'result']
         self.id = params[u'id']
-
-
-#
-#   Handle Connection Events.
-#
-
-def handle_connection_response(response):
-    # Handles complete notification and return ConnectionCompleteEvent object
-    # if connection successful.
-    def handle_connection_complete_notification(response):
-        if not response.connection_id:
-            sys.stderr.write(u'\nConnection did not succeed.')
-            if response.error_message:
-                sys.stderr.write(u'\nError message: ' + response.error_message)
-                logger.error(response.error_message)
-            if response.messages:
-                logger.error(response.messages)
-
-        return response
-
-    def handle_connection_response_notification(response):
-        if not response.result:
-            sys.stderr.write(
-                u'\nIncorrect json rpc request. Connection not successful.')
-        return None
-
-    response_handlers = {
-        u'ConnectionResponse': handle_connection_response_notification,
-        u'ConnectionCompleteEvent': handle_connection_complete_notification
-    }
-
-    response_name = type(response).__name__
-
-    if response_name in response_handlers:
-        return response_handlers[response_name](response)

--- a/mssqlcli/jsonrpc/contracts/tests/test_json_rpc_contracts.py
+++ b/mssqlcli/jsonrpc/contracts/tests/test_json_rpc_contracts.py
@@ -173,8 +173,6 @@ class JSONRPCContractsTests(unittest.TestCase):
                 elif isinstance(response, connectionservice.ConnectionCompleteEvent):
                     if response.connection_id:
                         complete_event += 1
-                        self.assertTrue(connectionservice.handle_connection_response(response).connection_id,
-                                        response.connection_id)
 
         self.assertEqual(response_event, expected_response_event)
         self.assertEqual(complete_event, expected_complete_event)

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -317,11 +317,12 @@ class MssqlCli(object):
                                                                  multi_subnet_failover=multi_subnet_failover,
                                                                  packet_size=packet_size, **kwargs)
 
-            if not self.mssqlcliclient_query_execution.connect():
+            owner_uri, error_messages = self.mssqlcliclient_query_execution.connect()
+            if not owner_uri:
                 click.secho(
-                    '\nUnable to connect. Please try again',
+                    '\n'.join(error_messages),
                     err=True,
-                    fg='red')
+                    fg='yellow')
                 exit(1)
 
             telemetry_session.set_server_information(

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -65,10 +65,10 @@ class MssqlCliClient(object):
     def connect(self):
         """
         Connects to the SQL Server instance using specified credentials
-        :return: OwnerUri if connection established else None
+        :return: Tuple (OwnerURI, list of error messages)
         """
         if self.is_connected:
-            return self.owner_uri
+            return self.owner_uri, []
 
         # Required params
         connection_params = {u'ServerName': self.server_name,
@@ -99,9 +99,16 @@ class MssqlCliClient(object):
             u'connection_request', connection_params, self.owner_uri)
         connection_request.execute()
 
+        error_messages = []
         while not connection_request.completed():
             response = connection_request.get_response()
-            if not response:
+
+            if isinstance(response, connectionservice.ConnectionCompleteEvent):
+                if response.error_message:
+                    error_messages.append(u'Error message: {}'.format(response.error_message))
+                if response.messages:
+                    error_messages.append(u'Additional message: {}'.format(response.messages))
+            else:
                 time.sleep(time_wait_if_no_response)
 
         if response and response.connection_id:
@@ -116,7 +123,10 @@ class MssqlCliClient(object):
             logger.info(
                 u'Connection Successful. Connection Id {0}'.format(
                     response.connection_id))
-            return self.owner_uri
+
+            return self.owner_uri, []
+
+        return None, error_messages
 
     def execute_multi_statement_single_batch(self, query):
         # Try to run first as special command
@@ -155,9 +165,8 @@ class MssqlCliClient(object):
         query_messages = []
         while not query_request.completed():
             query_response = query_request.get_response()
-            if query_response:
-                if isinstance(query_response, queryservice.QueryMessageEvent):
-                    query_messages.append(query_response)
+            if isinstance(query_response, queryservice.QueryMessageEvent):
+                query_messages.append(query_response)
             else:
                 sleep(time_wait_if_no_response)
 

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -101,10 +101,7 @@ class MssqlCliClient(object):
 
         while not connection_request.completed():
             response = connection_request.get_response()
-            if response:
-                response = connectionservice.handle_connection_response(
-                    response)
-            else:
+            if not response:
                 time.sleep(time_wait_if_no_response)
 
         if response and response.connection_id:

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -107,7 +107,7 @@ class MssqlCliClient(object):
                 if response.error_message:
                     error_messages.append(u'Error message: {}'.format(response.error_message))
                 if response.messages:
-                    error_messages.append(u'Additional message: {}'.format(response.messages))
+                    logger.error(response.messages)
             else:
                 time.sleep(time_wait_if_no_response)
 

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -1,8 +1,4 @@
 # coding=utf-8
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for license information.
-# --------------------------------------------------------------------------------------------
 import os
 import io
 import unittest
@@ -204,6 +200,7 @@ class MssqlCliClientTests(unittest.TestCase):
             list(client.execute_single_batch_query(del_stored_proc))
         finally:
             shutdown(client)
+
 
 if __name__ == u'__main__':
     unittest.main()


### PR DESCRIPTION
Connection service should maintain a single responsibility of supplying connection requests and handling responses. It should not output any error messages to the console as that should be the responsibility of the client (mssqlcliclient).

After reviewing the handle_connection_response method it only served as a logging/console writing function. This was discovered during bug bash that if any errors happened on the completion refresher thread, the error would be populated to the user which is not useful. 

The background thread for completion refresher is allowed to fail and should not interrupt the user's session if it does.
