### PR TITLE
Partial refactor of code base

### DIFF
--- a/build.py
+++ b/build.py
@@ -141,8 +141,9 @@ if __name__ == '__main__':
     actions = sys.argv[1:] or default_actions
 
     for action in actions:
-        if action in targets:
-            targets[action]()
+        current_action = action.lower()
+        if current_action in targets:
+            targets[current_action]()
         else:
-            print('{0} is not a supported action'.format(action[1]))
+            print('{0} is not a supported action'.format(current_action[1]))
             print('Supported actions are {}'.format(list(targets.keys())))

--- a/build.py
+++ b/build.py
@@ -128,6 +128,14 @@ def test():
     integration_test()
 
 
+def validate_actions(user_actions, valid_targets):
+    for user_action in user_actions:
+        if user_action.lower() not in valid_targets.keys():
+            print('{0} is not a supported action'.format(user_action))
+            print('Supported actions are {}'.format(list(valid_targets.keys())))
+            sys.exit(1)
+
+
 if __name__ == '__main__':
     default_actions = ['build', 'unit_test']
 
@@ -140,10 +148,7 @@ if __name__ == '__main__':
     }
     actions = sys.argv[1:] or default_actions
 
+    validate_actions(actions, targets)
+
     for action in actions:
-        current_action = action.lower()
-        if current_action in targets:
-            targets[current_action]()
-        else:
-            print('{0} is not a supported action'.format(current_action[1]))
-            print('Supported actions are {}'.format(list(targets.keys())))
+        targets[action]()

--- a/mssqlcli/completion_refresher.py
+++ b/mssqlcli/completion_refresher.py
@@ -51,7 +51,7 @@ class CompletionRefresher(object):
         completer = MssqlCompleter(smart_completion=True, settings=settings)
 
         executor = mssqlcliclient
-        owner_uri, error_messages = executor.connect()
+        owner_uri, error_messages = executor.connect_to_database()
 
         if not owner_uri:
             # If we were unable to connect, do not break the experience for the user.

--- a/mssqlcli/completion_refresher.py
+++ b/mssqlcli/completion_refresher.py
@@ -100,31 +100,31 @@ def refresher(name, refreshers=CompletionRefresher.refreshers):
 @refresher('schemata')
 @decorators.suppress_all_exceptions()
 def refresh_schemata(completer, mssqlcliclient):
-    completer.extend_schemata(mssqlcliclient.schemas())
+    completer.extend_schemata(mssqlcliclient.get_schemas())
 
 
 @refresher('tables')
 @decorators.suppress_all_exceptions()
 def refresh_tables(completer, mssqlcliclient):
-    completer.extend_relations(mssqlcliclient.tables(), kind='tables')
-    completer.extend_columns(mssqlcliclient.table_columns(), kind='tables')
-    completer.extend_foreignkeys(mssqlcliclient.foreignkeys())
+    completer.extend_relations(mssqlcliclient.get_tables(), kind='tables')
+    completer.extend_columns(mssqlcliclient.get_table_columns(), kind='tables')
+    completer.extend_foreignkeys(mssqlcliclient.get_foreign_keys())
 
 
 @refresher('views')
 @decorators.suppress_all_exceptions()
 def refresh_views(completer, mssqlcliclient):
-    completer.extend_relations(mssqlcliclient.views(), kind='views')
-    completer.extend_columns(mssqlcliclient.view_columns(), kind='views')
+    completer.extend_relations(mssqlcliclient.get_views(), kind='views')
+    completer.extend_columns(mssqlcliclient.get_view_columns(), kind='views')
 
 
 @refresher('databases')
 @decorators.suppress_all_exceptions()
 def refresh_databases(completer, mssqlcliclient):
-    completer.extend_database_names(mssqlcliclient.databases())
+    completer.extend_database_names(mssqlcliclient.get_databases())
 
 
 @refresher('types')
 @decorators.suppress_all_exceptions()
 def refresh_types(completer, mssqlcliclient):
-    completer.extend_datatypes(mssqlcliclient.user_defined_types())
+    completer.extend_datatypes(mssqlcliclient.get_user_defined_types())

--- a/mssqlcli/jsonrpc/contracts/connectionservice.py
+++ b/mssqlcli/jsonrpc/contracts/connectionservice.py
@@ -88,7 +88,6 @@ class ConnectionDetails(object):
         self.UserName = parameters[u'UserName']
         self.Password = parameters[u'Password']
         self.AuthenticationType = parameters[u'AuthenticationType']
-        self.MultipleActiveResultSets = parameters[u'MultipleActiveResultSets']
         # Optional Params
         if u'Encrypt' in parameters:
             self.Encrypt = parameters[u'Encrypt']

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -366,18 +366,17 @@ class MssqlCli(object):
         try:
             sql_tools_client.shutdown()
             new_tools_client = SqlToolsClient()
-            for mssqlcliclient in mssqlcliclients:
-                mssqlcliclient.sql_tools_client = new_tools_client
-                mssqlcliclient.is_connected = False
-                mssqlcliclient.owner_uri = generate_owner_uri()
-                if not mssqlcliclient.connect_to_database_with():
-                    click.secho('Unable reconnect to server {0}; database {1}.'.format(mssqlcliclient.server_name,
-                                                                                       mssqlcliclient.database),
-                                err=True, fg='red')
-                    self.logger.info(
-                        u'Unable to reset connection to server {0}; database {1}'.format(
-                            mssqlcliclient.server_name,
-                            mssqlcliclient.database))
+            for mssqlcli_client in mssqlcliclients:
+                mssqlcli_client.sql_tools_client = new_tools_client
+                mssqlcli_client.is_connected = False
+                mssqlcli_client.owner_uri = generate_owner_uri()
+                if not mssqlcli_client.connect_to_database_with():
+                    click.secho('Unable reconnect to server {0}; database {1}.'.format(mssqlcli_client.server_name,
+                                                                                       mssqlcli_client.database),
+                                err=True, fg='yellow')
+                    self.logger.info(u'Unable to reset connection to server {0}; database {1}'.format(
+                            mssqlcli_client.server_name,
+                            mssqlcli_client.database))
                     exit(1)
 
         except Exception as e:
@@ -533,7 +532,7 @@ class MssqlCli(object):
             exit(1)
 
         for rows, columns, status, sql, is_error in \
-                self.mssqlcliclient_main.execute_multi_statement_single_batch(text):
+                self.mssqlcliclient_main.execute_multi_statement(text):
             total = time() - start
             if self._should_show_limit_prompt(status, rows):
                 click.secho('The result set has more than %s rows.'
@@ -829,7 +828,7 @@ def format_output(title, cur, headers, status, settings):
     if not settings.floatfmt:
         output_kwargs['preprocessors'] = (align_decimals, )
 
-    if title:  # Only print the title if it's not None.
+    if title:
         output.append(title)
 
     if cur:

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -316,7 +316,7 @@ class MssqlCli(object):
             # Right now the sql_tools_service process is killed and we restart
             # it with a new connection.
             click.secho(u'Cancelling query...', err=True, fg='red')
-            self.reset_connection()
+            self.reset()
             logger.debug("cancelled query, sql: %r", text)
             click.secho("Query cancelled.", err=True, fg='red')
 
@@ -559,13 +559,13 @@ class MssqlCli(object):
             show_default=False, type=bool, default=True)
         if reconnect:
             try:
-                self.reset_connection()
+                self.reset()
 
                 click.secho('Reconnected!\nTry the command again.', fg='green')
             except Exception as e:
                 click.secho(str(e), err=True, fg='red')
 
-    def reset_connection(self):
+    def reset(self):
         """
         Reset mssqlcli client with a new sql tools service and connection.
         """
@@ -573,9 +573,7 @@ class MssqlCli(object):
             self.sqltoolsclient.shutdown()
             self.sqltoolsclient = SqlToolsClient()
 
-            self.mssqlcliclient_main.sql_tools_client = self.sqltoolsclient
-            self.mssqlcliclient_main.is_connected = False
-            self.mssqlcliclient_main.owner_uri = generate_owner_uri()
+            self.mssqlcliclient_main = self.mssqlcliclient_main.clone(self.sqltoolsclient)
 
             if not self.mssqlcliclient_main.connect_to_database():
                 click.secho('Unable reconnect to server {0}; database {1}.'.format(

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import getpass
 import os
 import sys
 import traceback
@@ -14,6 +15,7 @@ from time import time
 from codecs import open
 import platform
 
+from builtins import input
 from cli_helpers.tabular_output import TabularOutputFormatter
 from cli_helpers.tabular_output.preprocessors import (align_decimals,
                                                       format_numbers)
@@ -56,9 +58,9 @@ except ImportError:
 from collections import namedtuple
 
 # mssql-cli imports
-import mssqlclioptionsparser as parser
-import mssqlcli.sqltoolsclient as SqlToolsClient
-from mssqlcli.mssqlcliclient import MssqlCliClient, reset_connection_and_clients
+import mssqlcli.mssqlclioptionsparser as parser
+from mssqlcli.sqltoolsclient import SqlToolsClient
+from mssqlcli.mssqlcliclient import MssqlCliClient, generate_owner_uri
 from mssqlcli.packages import special
 import mssqlcli.telemetry as telemetry_session
 
@@ -124,9 +126,7 @@ class MssqlCli(object):
             os.environ['LESS'] = '-SRXF'
 
     # mssql-cli
-    def __init__(self, options, sql_tools_client=None):
-
-        self.force_passwd_prompt = options.force_passwd_prompt
+    def __init__(self, options):
 
         # Load config.
         c = self.config = get_config(options.mssqlclirc_file)
@@ -178,23 +178,19 @@ class MssqlCli(object):
             'qualify_columns': c['main']['qualify_columns'],
             'case_column_headers': c['main'].as_bool('case_column_headers'),
             'search_path_filter': c['main'].as_bool('search_path_filter'),
-            'single_connection': options.single_connection,
+            'single_connection': False,
             'less_chatty': options.less_chatty,
             'keyword_casing': keyword_casing,
         }
 
-        completer = MssqlCompleter(smart_completion=smart_completion, settings=self.settings)
-
-        self.completer = completer
+        self.completer = MssqlCompleter(smart_completion=smart_completion, settings=self.settings)
         self._completer_lock = threading.Lock()
 
         self.eventloop = create_eventloop()
         self.cli = None
 
-        # mssql-cli
-        self.sqltoolsclient = sql_tools_client if sql_tools_client else SqlToolsClient(
-            enable_logging=options.enable_sqltoolsservice_logging)
-        self.mssqlcliclient_query_execution = None
+        self.sqltoolsclient = SqlToolsClient(enable_logging=options.enable_sqltoolsservice_logging)
+        self.mssqlcliclient_main = None
         self.integrated_auth = options.integrated_auth
 
     def __del__(self):
@@ -258,71 +254,22 @@ class MssqlCli(object):
         root_logger.info('Initializing mssqlcli logging.')
         root_logger.debug('Log file %r.', log_file)
 
-    def connect(self, options, user='', port='', passwd='', **kwargs):
-        # Connect to the database.
+    def connect_to_database_with(self, mssqlcli_client):
 
-        if options.user and not self.integrated_auth:
-            # TODO
-            user = click.prompt(
-                'Username (press enter for sa)',
-                default=u'sa',
-                show_default=False)
-
-        # If password prompt is not forced but no password is provided, try
-        # getting it from environment variable.
-        if not self.force_passwd_prompt and not options.passwd:
-            passwd = os.environ.get('MSSQL_CLI_PASSWORD', '')
-
-        if not self.integrated_auth:
-            # Prompt for a password immediately if requested via the -W flag. This
-            # avoids wasting time trying to connect to the database and catching a
-            # no-password exception.
-            # If we successfully parsed a password from a URI, there's no need to
-            # prompt for it, even with the -W flag
-            if self.force_passwd_prompt and not options.passwd:
-                passwd = click.prompt('Password', hide_input=True,
-                                      show_default=False, type=str)
-
-            if not passwd:
-                passwd = click.prompt('Password', hide_input=True,
-                                      show_default=False, type=str)
-
-        # Attempt to connect to the database.
-        # Note that passwd may be empty on the first attempt. In this case try
-        # integrated auth.
         try:
-            # mssql-cli
-            authentication_type = u'SqlLogin'
-            if self.integrated_auth:
-                authentication_type = u'Integrated'
 
-            self.mssqlcliclient_query_execution = MssqlCliClient(self.sqltoolsclient,
-                                                                 options.server,
-                                                                 user, passwd,
-                                                                 database=options.database,
-                                                                 authentication_type=authentication_type,
-                                                                 encrypt=options.encrypt,
-                                                                 trust_server_certificate=options.trust_server_certificate,
-                                                                 connection_timeout=options.connection_timeout,
-                                                                 application_intent=options.application_intent,
-                                                                 multi_subnet_failover=options.multi_subnet_failover,
-                                                                 packet_size=options.packet_size, **kwargs)
-
-            owner_uri, error_messages = self.mssqlcliclient_query_execution.connect()
-            if not owner_uri:
-                click.secho(
-                    '\n'.join(error_messages),
-                    err=True,
-                    fg='yellow')
+            self.mssqlcliclient_main = mssqlcli_client
+            owner_uri, error_messages = self.mssqlcliclient_main.connect_to_database()
+            if not owner_uri and error_messages:
+                click.secho('\n'.join(error_messages),
+                            err=True,
+                            fg='yellow')
                 exit(1)
 
-            telemetry_session.set_server_information(
-                self.mssqlcliclient_query_execution)
-
-        except Exception as e:  # Connecting to a database could fail.
+        except Exception as e:
             self.logger.debug('Database connection failed: %r.', e)
             self.logger.error("traceback: %r", traceback.format_exc())
-            click.secho(str(e), err=True, fg='red')
+            click.secho(str(e), err=True, fg='yellow')
             exit(1)
 
     def handle_editor_command(self, cli, document):
@@ -369,7 +316,7 @@ class MssqlCli(object):
             # it with a new connection.
             click.secho(u'Cancelling query...', err=True, fg='red')
             reset_connection_and_clients(self.sqltoolsclient,
-                                         self.mssqlcliclient_query_execution)
+                                         self.mssqlcliclient_main)
             logger.debug("cancelled query, sql: %r", text)
             click.secho("Query cancelled.", err=True, fg='red')
 
@@ -411,7 +358,33 @@ class MssqlCli(object):
 
         return query
 
-    def run_cli(self):
+    def reset_connection_and_clients(self, sql_tools_client, *mssqlcliclients):
+        """
+        Restarts the sql_tools_client and establishes new connections for each of the
+        mssqlcliclients passed
+        """
+        try:
+            sql_tools_client.shutdown()
+            new_tools_client = SqlToolsClient()
+            for mssqlcliclient in mssqlcliclients:
+                mssqlcliclient.sql_tools_client = new_tools_client
+                mssqlcliclient.is_connected = False
+                mssqlcliclient.owner_uri = generate_owner_uri()
+                if not mssqlcliclient.connect_to_database_with():
+                    click.secho('Unable reconnect to server {0}; database {1}.'.format(mssqlcliclient.server_name,
+                                                                                       mssqlcliclient.database),
+                                err=True, fg='red')
+                    self.logger.info(
+                        u'Unable to reset connection to server {0}; database {1}'.format(
+                            mssqlcliclient.server_name,
+                            mssqlcliclient.database))
+                    exit(1)
+
+        except Exception as e:
+            self.logger.error(u'Error in reset_connection : {0}'.format(e.message))
+            raise e
+
+    def run(self):
         history_file = self.config['main']['history_file']
         if history_file == 'default':
             history_file = config_location() + 'history'
@@ -459,9 +432,9 @@ class MssqlCli(object):
                 self.query_history.append(query)
 
         except EOFError:
-            self.mssqlcliclient_query_execution.shutdown()
+            self.mssqlcliclient_main.shutdown()
             if not self.less_chatty:
-                print ('Goodbye!')
+                print('Goodbye!')
 
     def _build_cli(self, history):
 
@@ -555,12 +528,12 @@ class MssqlCli(object):
         start = time()
 
         # mssql-cli
-        if not self.mssqlcliclient_query_execution.connect():
+        if not self.mssqlcliclient_main.connect_to_database_with():
             click.secho(u'No connection to server. Exiting.')
             exit(1)
 
         for rows, columns, status, sql, is_error in \
-                self.mssqlcliclient_query_execution.execute_multi_statement_single_batch(text):
+                self.mssqlcliclient_main.execute_multi_statement_single_batch(text):
             total = time() - start
             if self._should_show_limit_prompt(status, rows):
                 click.secho('The result set has more than %s rows.'
@@ -599,7 +572,7 @@ class MssqlCli(object):
             db_changed, new_db_name = has_change_db_cmd(sql, db_changed)
             if new_db_name:
                 logger.info('Database context changed.')
-                self.mssqlcliclient_query_execution.database = new_db_name
+                self.mssqlcliclient_main.database = new_db_name
 
             if all_success:
                 meta_changed = meta_changed or has_meta_cmd(text)
@@ -614,8 +587,8 @@ class MssqlCli(object):
             show_default=False, type=bool, default=True)
         if reconnect:
             try:
-                reset_connection_and_clients(self.sqltoolsclient,
-                                             self.mssqlcliclient_query_execution)
+                self.reset_connection_and_clients(self.sqltoolsclient,
+                                                  self.mssqlcliclient_main)
 
                 click.secho('Reconnected!\nTry the command again.', fg='green')
             except Exception as e:
@@ -630,7 +603,7 @@ class MssqlCli(object):
         :param persist_priorities: 'all' or 'keywords'
         """
         # Clone mssqlcliclient to create a new connection with a new owner Uri.
-        mssqlclclient_completion_refresher = self.mssqlcliclient_query_execution.clone()
+        mssqlclclient_completion_refresher = self.mssqlcliclient_main.clone()
 
         callback = functools.partial(self._on_completions_refreshed,
                                      persist_priorities=persist_priorities)
@@ -695,10 +668,10 @@ class MssqlCli(object):
     def get_prompt(self, string):
         # mssql-cli
         string = string.replace('\\t', self.now.strftime('%x %X'))
-        string = string.replace('\\u', self.mssqlcliclient_query_execution.user_name or '(none)')
-        string = string.replace('\\h', self.mssqlcliclient_query_execution.prompt_host or '(none)')
-        string = string.replace('\\d', self.mssqlcliclient_query_execution.database or '(none)')
-        string = string.replace('\\p', str(self.mssqlcliclient_query_execution.prompt_port) or '(none)')
+        string = string.replace('\\u', self.mssqlcliclient_main.user_name or '(none)')
+        string = string.replace('\\h', self.mssqlcliclient_main.prompt_host or '(none)')
+        string = string.replace('\\d', self.mssqlcliclient_main.database or '(none)')
+        string = string.replace('\\p', str(self.mssqlcliclient_main.prompt_port) or '(none)')
         string = string.replace('\\n', "\n")
         return string
 
@@ -707,43 +680,56 @@ class MssqlCli(object):
         return self.query_history[-1][0] if self.query_history else None
 
 
-def run_cli(username, server, prompt_passwd,
-        database, version, mssqlclirc,
-        row_limit, less_chatty, auto_vertical_output,
-        integrated_auth, encrypt, trust_server_certificate,
-        connect_timeout, application_intent, multi_subnet_failover,
-        packet_size, enable_sqltoolsservice_logging, dac_connection, prompt, options):
+def run_cli_with(options):
 
-    if options.version:
-        print('Version:', __version__)
-        sys.exit(0)
-
-    config_dir = os.path.dirname(config_location())
-    if not os.path.exists(config_dir):
-        os.makedirs(config_dir)
+    if create_config_dir_for_first_use():
         display_telemetry_message()
 
-    if platform.system().lower() != 'windows' and options.integrated_auth:
-        options.integrated_auth = False
-        print (u'Integrated authentication not supported on this platform')
+    display_version_message(options)
+    display_integrated_auth_message_for_non_windows(options)
 
-    if dac_connection and options.server and not options.server.lower().startswith("admin:"):
-        options.server = "admin:" + options.server
+    configure_and_update_options(options)
 
     mssqlcli = MssqlCli(options)
 
-    mssqlcli.connect(database, server, username, port='', encrypt=encrypt,
-                     trust_server_certificate=trust_server_certificate, connection_timeout=connect_timeout,
-                     application_intent=application_intent, multi_subnet_failover=multi_subnet_failover,
-                     packet_size=packet_size)
+    mssqlcli_client = MssqlCliClient(options, mssqlcli.sqltoolsclient)
+    mssqlcli.connect_to_database_with(mssqlcli_client)
 
-    mssqlcli.logger.debug('Launch Params: \n'
-                          '\tdatabase: %r'
-                          '\tuser: %r'
-                          '\tserver: %r'
-                          '\tport: %r', database, username, server, '')
+    telemetry_session.set_server_information(mssqlcli_client)
 
-    mssqlcli.run_cli()
+    mssqlcli.run()
+
+
+def configure_and_update_options(options):
+    if options.dac_connection and options.server and not options.server.lower().startswith("admin:"):
+        options.server = "admin:" + options.server
+
+    if not options.integrated_auth:
+        if not mssqlcli_options.username:
+            mssqlcli_options.username = input(u'Username (press enter for sa)') or u'sa'
+        if not mssqlcli_options.password:
+            mssqlcli_options.password = getpass.getpass()
+
+
+def create_config_dir_for_first_use():
+    config_dir = os.path.dirname(config_location())
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+        return True
+
+    return False
+
+
+def display_integrated_auth_message_for_non_windows(options):
+    if platform.system().lower() != 'windows' and options.integrated_auth:
+        options.integrated_auth = False
+        print(u'Integrated authentication not supported on this platform')
+
+
+def display_version_message(options):
+    if options.version:
+        print('Version:', __version__)
+        sys.exit(0)
 
 
 def display_telemetry_message():
@@ -874,8 +860,8 @@ def format_output(title, cur, headers, status, settings):
 if __name__ == "__main__":
     try:
         telemetry_session.start()
-        options = parser.parse(sys.argv[1:])
-        run_cli(options)
+        mssqlcli_options = parser.parse(sys.argv[1:])
+        run_cli_with(mssqlcli_options)
     finally:
         # Upload telemetry async in a separate process.
         telemetry_session.conclude()

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -586,7 +586,7 @@ class MssqlCli(object):
                     self.mssqlcliclient_main.database))
                 exit(1)
         except Exception as e:
-            self.logger.error(u'Error in reset_connection : {0}'.format(e.message))
+            self.logger.error(u'Error in reset : {0}'.format(e.message))
             raise e
 
     def refresh_completions(self, history=None, persist_priorities='all'):

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -21,6 +21,10 @@ def generate_owner_uri():
     return u'mssql-cli-' + uuid.uuid4().urn
 
 
+SQLTOOLSSERVICE_CONNECTION_REQUEST = u'connection_request'
+SQLTOOLSSERVICE_QUERY_EXECUTE_STRING_REQUEST = u'query_execute_string_request'
+SQLTOOLSSERVICE_QUERY_SUBSET_REQUEST = u'query_subset_request'
+
 class MssqlCliClient(object):
 
     def __init__(self, mssqlcli_options, sql_tools_client, owner_uri=None, **kwargs):
@@ -43,16 +47,14 @@ class MssqlCliClient(object):
         self.multi_subnet_failover = mssqlcli_options.multi_subnet_failover
         self.packet_size = mssqlcli_options.packet_size
 
-        self.extra_params = {k: v for k, v in kwargs.items()}
-        self.owner_uri = owner_uri
-        self.is_connected = False
+        self.owner_uri = owner_uri if owner_uri else generate_owner_uri()
         self.sql_tools_client = sql_tools_client
+        self.is_connected = False
         self.server_version = None
         self.server_edition = None
         self.is_cloud = False
 
-        if not owner_uri:
-            self.owner_uri = generate_owner_uri()
+        self.extra_params = {k: v for k, v in kwargs.items()}
 
         logger.info(u'Initialized MssqlCliClient with owner Uri {}'.format(self.owner_uri))
 
@@ -87,15 +89,77 @@ class MssqlCliClient(object):
         connection_params = self.get_base_connection_params()
         connection_params = self.add_optional_connection_params(connection_params)
 
-        owner_uri, error_messages = self.execute_connection_request_with(connection_params)
+        owner_uri, error_messages = self._execute_connection_request_with(connection_params)
 
         return owner_uri, error_messages
 
-    def execute_connection_request_with(self, connection_params):
+    def execute_multi_statement(self, query):
+        # Try to run first as special command
+        try:
+            for rows, columns, status, statement, is_error in special.execute(self, query):
+                yield rows, columns, status, statement, is_error
+        except special.CommandNotFound:
+            # Execute as normal sql
+            # Remove spaces, EOL and semi-colons from end
+            query = query.strip()
+            if not query:
+                yield None, None, None, query, False
+            else:
+                for single_query in sqlparse.split(query):
+                    # Remove spaces, EOL and semi-colons from end
+                    single_query = single_query.strip().rstrip(';')
+                    if single_query:
+                        for rows, columns, status, statement, is_error in self.execute_single_statement(single_query):
+                            yield rows, columns, status, statement, is_error
+                    else:
+                        yield None, None, None, None, False
+                        continue
+
+    def execute_single_statement(self, query):
+        query_response, query_messages, query_had_error = self._execute_query_execute_request_for(query)
+
+        if self._exception_found_in(query_response):
+            yield self._generate_query_results(query=query,
+                                               message=query_response.exception_message,
+                                               is_error=query_had_error)
+            return
+
+        if self._no_results_found_in(query_response) or self._no_rows_found_in(query_response):
+            query_message = query_messages[0].message if query_messages else u''
+            yield self._generate_query_results(query=query,
+                                               message=query_message,
+                                               is_error=query_had_error)
+
+            return
+
+        query_subset_responses_and_summaries = self._execute_query_subset_request_for(query_response)
+
+        for query_subset_response, result_set_summary in query_subset_responses_and_summaries:
+            if self._error_message_found_in(query_subset_response):
+                yield self._generate_query_results(query=query,
+                                                   message=query_subset_response.error_message,
+                                                   is_error=True)
+
+            query_message_for_current_result_set = query_messages[result_set_summary.id].message \
+                                                    if query_messages else u''
+
+            yield self._generate_query_results(column_info=result_set_summary.column_info,
+                                               result_rows=query_subset_response.rows,
+                                               query=query,
+                                               message=query_message_for_current_result_set)
+
+    def clone(self):
+        cloned_mssqlcli_client = copy.copy(self)
+        cloned_mssqlcli_client.owner_uri = generate_owner_uri()
+        cloned_mssqlcli_client.is_connected = False
+
+        return cloned_mssqlcli_client
+
+    def _execute_connection_request_with(self, connection_params):
         if self.is_connected:
             return self.owner_uri, []
 
-        connection_request = self.sql_tools_client.create_request(u'connection_request',
+        connection_request = self.sql_tools_client.create_request(self.sql_tools_client.CONNECTION_REQUEST,
                                                                   connection_params,
                                                                   self.owner_uri)
         connection_request.execute()
@@ -124,44 +188,23 @@ class MssqlCliClient(object):
                 u'Connection Successful. Connection Id {0}'.format(
                     response.connection_id))
 
-            return self.owner_uri, []
+            return self.owner_uri, error_messages
 
         return None, error_messages
 
-    def execute_multi_statement_single_batch(self, query):
-        # Try to run first as special command
-        try:
-            for rows, columns, status, statement, is_error in special.execute(self, query):
-                yield rows, columns, status, statement, is_error
-        except special.CommandNotFound:
-            # Execute as normal sql
-            # Remove spaces, EOL and semi-colons from end
-            query = query.strip()
-            if not query:
-                yield None, None, None, query, False
-            else:
-                for sql in sqlparse.split(query):
-                    # Remove spaces, EOL and semi-colons from end
-                    sql = sql.strip().rstrip(';')
-                    if not sql:
-                        yield None, None, None, sql, False
-                        continue
-                    for rows, columns, status, statement, is_error in self.execute_single_batch_query(sql):
-                        yield rows, columns, status, statement, is_error
-
-    def execute_single_batch_query(self, query):
+    def _execute_query_execute_request_for(self, query):
         if not self.is_connected:
-            click.secho(
-                u'No connection established with the server.',
-                err=True,
-                fg='yellow')
+            click.secho(u'No connection established with the server.',
+                        err=True,
+                        fg='yellow')
             exit(1)
 
-        query_request = self.sql_tools_client.create_request(u'query_execute_string_request',
+        query_request = self.sql_tools_client.create_request(self.sql_tools_client.QUERY_EXECUTE_STRING_REQUEST,
                                                              {u'OwnerUri': self.owner_uri,
                                                               u'Query': query},
                                                              self.owner_uri)
         query_request.execute()
+        query_response = None
         query_messages = []
         while not query_request.completed():
             query_response = query_request.get_response()
@@ -170,137 +213,120 @@ class MssqlCliClient(object):
             else:
                 sleep(time_wait_if_no_response)
 
-        if query_response.exception_message:
-            logger.error(u'Query response had an exception')
-            yield self.tabular_results_generator(
-                column_info=None,
-                result_rows=None,
-                query=query,
-                message=query_response.exception_message,
-                is_error=True)
-            return
+        query_has_exception = query_response.exception_message
+        query_has_error_messages = query_messages[0].is_error if query_messages else False
+        query_has_batch_error = query_response.batch_summaries[0].has_error
 
-        if (not query_response.batch_summaries[0].result_set_summaries) or \
-           (query_response.batch_summaries[0].result_set_summaries[0].row_count == 0):
-            yield self.tabular_results_generator(
-                column_info=None,
-                result_rows=None,
-                query=query,
-                message=query_messages[0].message if query_messages else u'',
-                is_error=query_messages[0].is_error if query_messages else query_response.batch_summaries[0].has_error)
+        query_failed = query_has_exception or query_has_batch_error or query_has_error_messages
+        return query_response, query_messages, query_failed
 
-        else:
-            for result_set_summary in query_response.batch_summaries[0].result_set_summaries:
-                query_subset_request = self.sql_tools_client.create_request(u'query_subset_request',
-                                                                            {u'OwnerUri': query_response.owner_uri,
-                                                                             u'BatchIndex': result_set_summary.batch_id,
-                                                                             u'ResultSetIndex': result_set_summary.id,
-                                                                             u'RowsStartIndex': 0,
-                                                                             u'RowCount': result_set_summary.row_count},
-                                                                            self.owner_uri)
+    def _execute_query_subset_request_for(self, query_response):
+        subset_responses_and_summaries = []
+        for result_set_summary in query_response.batch_summaries[0].result_set_summaries:
+            query_subset_request = self.sql_tools_client.create_request(self.sql_tools_client.QUERY_SUBSET_REQUEST,
+                                                                        {u'OwnerUri': query_response.owner_uri,
+                                                                         u'BatchIndex': result_set_summary.batch_id,
+                                                                         u'ResultSetIndex': result_set_summary.id,
+                                                                         u'RowsStartIndex': 0,
+                                                                         u'RowCount': result_set_summary.row_count},
+                                                                        self.owner_uri)
 
-                query_subset_request.execute()
-                while not query_subset_request.completed():
-                    subset_response = query_subset_request.get_response()
-                    if not subset_response:
-                        sleep(time_wait_if_no_response)
+            query_subset_request.execute()
 
-                logger.info('Getting response for id {}'.format(query_subset_request.id))
-                if subset_response.error_message:
-                    logger.error(u'Error obtaining result sets for query response for id {}'.format(query_subset_request.id))
-                    logger.error(u'Error Message: {}'.format(subset_response.error_message))
-                    yield self.tabular_results_generator(
-                        column_info=None,
-                        result_rows=None,
-                        query=query,
-                        message=subset_response.error_message,
-                        is_error=True)
+            query_subset_response = None
+            while not query_subset_request.completed():
+                query_subset_response = query_subset_request.get_response()
+                if not query_subset_response:
+                    sleep(time_wait_if_no_response)
 
-                yield self.tabular_results_generator(
-                    column_info=result_set_summary.column_info,
-                    result_rows=subset_response.rows,
-                    query=query,
-                    message=query_messages[result_set_summary.id].message if query_messages else u'')
+            subset_responses_and_summaries.add((query_subset_response, result_set_summary))
 
-    def tabular_results_generator(self, column_info, result_rows, query, message, is_error=False):
+        return subset_responses_and_summaries
+
+    def _error_message_found_in(self, query_subset_response):
+        return query_subset_response.error_message
+
+    def _exception_found_in(self, query_response):
+        return query_response.exception_message
+
+    def _no_results_found_in(self, query_response):
+        return not query_response.batch_summaries[0].result_set_summaries
+
+    def _no_rows_found_in(self, query_response):
+        return query_response.batch_summaries[0].result_set_summaries[0].row_count == 0
+
+    def _generate_query_results(self, query, message, column_info=None, result_rows=None, is_error=False):
         # Returns a generator of rows, columns, status(rows affected) or
         # message, sql (the query), is_error
         if is_error:
             return (), None, message, query, is_error
 
-        columns = [
-            col.column_name for col in column_info] if column_info else None
+        columns = [col.column_name for col in column_info] if column_info else None
+
         rows = ([[cell.display_value for cell in result_row.result_cells]
                  for result_row in result_rows]) if result_rows else ()
 
         return rows, columns, message, query, is_error
 
-    def clone(self):
-        cloned_mssqlcli_client = copy.copy(self)
-        cloned_mssqlcli_client.owner_uri = generate_owner_uri()
-        cloned_mssqlcli_client.is_connected = False
-
-        return cloned_mssqlcli_client
-
-    def schemas(self):
+    def get_schemas(self):
         """ Returns a list of schema names"""
         query = mssqlqueries.get_schemas()
         logger.info(u'Schemas query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             return [x[0] for x in tabular_result[0]]
 
-    def databases(self):
+    def get_databases(self):
         """ Returns a list of database names"""
         query = mssqlqueries.get_databases()
         logger.info(u'Databases query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             return [x[0] for x in tabular_result[0]]
 
-    def tables(self):
+    def get_tables(self):
         """ Yields (schema_name, table_name) tuples"""
         query = mssqlqueries.get_tables()
         logger.info(u'Tables query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield (row[0], row[1])
 
-    def table_columns(self):
+    def get_table_columns(self):
         """ Yields (schema_name, table_name, column_name, data_type, column_default) tuples"""
         query = mssqlqueries.get_table_columns()
         logger.info(u'Table columns query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield (row[0], row[1], row[2], row[3], row[4])
 
-    def views(self):
+    def get_views(self):
         """ Yields (schema_name, table_name) tuples"""
         query = mssqlqueries.get_views()
         logger.info(u'Views query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield (row[0], row[1])
 
-    def view_columns(self):
+    def get_view_columns(self):
         """ Yields (schema_name, table_name, column_name, data_type, column_default) tuples"""
         query = mssqlqueries.get_view_columns()
         logger.info(u'View columns query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield (row[0], row[1], row[2], row[3], row[4])
 
-    def user_defined_types(self):
+    def get_user_defined_types(self):
         """ Yields (schema_name, type_name) tuples"""
         query = mssqlqueries.get_user_defined_types()
         logger.info(u'UDTs query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield (row[0], row[1])
 
-    def foreignkeys(self):
+    def get_foreign_keys(self):
         """ Yields (parent_schema, parent_table, parent_column, child_schema, child_table, child_column) typles"""
         query = mssqlqueries.get_foreignkeys()
         logger.info(u'Foreign keys query: {0}'.format(query))
-        for tabular_result in self.execute_single_batch_query(query):
+        for tabular_result in self.execute_single_statement(query):
             for row in tabular_result[0]:
                 yield ForeignKey(*row)
 

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -1,18 +1,17 @@
 
+import click
 import copy
 import logging
+import sqlparse
 import time
 import uuid
-from time import sleep
-
-import click
-import sqlparse
 
 from mssqlcli import mssqlqueries
 from mssqlcli.jsonrpc.contracts import connectionservice, queryexecutestringservice as queryservice
 from mssqlcli.packages import special
 from mssqlcli.packages.parseutils.meta import ForeignKey
 from mssqlcli.sqltoolsclient import SqlToolsClient
+from time import sleep
 
 logger = logging.getLogger(u'mssqlcli.mssqlcliclient')
 time_wait_if_no_response = 0.05

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -141,10 +141,13 @@ class MssqlCliClient(object):
                                                              query=query,
                                                              message=query_message_for_current_result_set)
 
-    def clone(self):
+    def clone(self, sqltoolsclient=None):
         cloned_mssqlcli_client = copy.copy(self)
         cloned_mssqlcli_client.owner_uri = generate_owner_uri()
         cloned_mssqlcli_client.is_connected = False
+
+        if sqltoolsclient:
+            cloned_mssqlcli_client.sql_tools_client = sqltoolsclient
 
         return cloned_mssqlcli_client
 

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -13,109 +13,109 @@ MSSQL_CLI_RC = u'MSSQL_CLI_RC'
 
 
 def initialize():
-    parser = argparse.ArgumentParser(
+    args_parser = argparse.ArgumentParser(
         prog=u'mssql-cli',
         description=u'Microsoft SQL Server CLI. ' +
         u'Version {}'.format(mssqlcli.__version__))
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-U', u'--username',
         dest=u'username',
         default=os.environ.get(MSSQL_CLI_USER, None),
         metavar=u'',
         help=u'Username to connect to the database')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-P', u'--password',
         dest=u'password',
         default=os.environ.get(MSSQL_CLI_PASSWORD, None),
         metavar=u'',
         help=u'If not supplied, defaults to value in environment variable MSSQL_CLI_PASSWORD.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-d', u'--database',
         dest=u'database',
         default=os.environ.get(MSSQL_CLI_DATABASE, u'master'),
         metavar=u'',
         help=u'database name to connect to.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-S', u'--server',
         dest=u'server',
         default=os.environ.get(MSSQL_CLI_SERVER, u'localhost'),
         metavar=u'',
         help=u'SQL Server instance name or address.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-I', u'--integrated',
         dest=u'integrated_auth',
         action=u'store_true',
         default=False,
         help=u'Use integrated authentication on windows.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-v', u'--version',
         dest=u'version',
         action=u'store_true',
         default=False,
         help=u'Version of mssql-cli.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--mssqlclirc',
         dest=u'mssqlclirc_file',
         default=os.environ.get(MSSQL_CLI_RC, config_location() + 'config'),
         metavar=u'',
         help=u'Location of mssqlclirc config file.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--row-limit',
         dest=u'row_limit',
         default=os.environ.get(MSSQL_CLI_ROW_LIMIT, None),
         metavar=u'',
         help=u'Set threshold for row limit prompt. Use 0 to disable prompt.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--less-chatty',
         dest=u'less_chatty',
         action=u'store_true',
         default=False,
         help=u'Skip intro on startup and goodbye on exit.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--auto-vertical-output',
         dest=u'auto_vertical_output',
         action=u'store_true',
         default=False,
         help=u'Automatically switch to vertical output mode if the result is wider than the terminal width.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-N', u'--encrypt',
         dest=u'encrypt',
         action=u'store_true',
         default=False,
         help=u'SQL Server uses SSL encryption for all data if the server has a certificate installed.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-C', u'--trust-server-certificate',
         dest=u'trust_server_certificate',
         action=u'store_true',
         default=False,
         help=u'The channel will be encrypted while bypassing walking the certificate chain to validate trust.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-l', u'--connect-timeout',
         dest=u'connection_timeout',
         default=0,
         metavar=u'',
         help=u'Time in seconds to wait for a connection to the server before terminating request.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-K', u'--application-intent',
         dest=u'application_intent',
         metavar=u'',
         help=u'Declares the application workload type when connecting to a database in a SQL Server Availability Group.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-M', u'--multi-subnet-failover',
         dest=u'multi_subnet_failover',
         action=u'store_true',
@@ -123,39 +123,37 @@ def initialize():
         help=u'If application is connecting to AlwaysOn AG on different subnets, setting this provides faster '
              u'detection and connection to currently active server.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-a', u'--packet-size',
         dest=u'packet_size',
         default=0,
         metavar=u'',
         help=u'Size in bytes of the network packets used to communicate with SQL Server.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'-A', u'--dac-connection',
         dest=u'dac_connection',
         action=u'store_true',
         default=False,
         help=u'Connect to SQL Server using the dedicated administrator connection.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--enable-sqltoolsservice-logging',
         dest=u'enable_sqltoolsservice_logging',
         action=u'store_true',
         default=False,
         help=u'Enables diagnostic logging for the SqlToolsService.')
 
-    parser.add_argument(
+    args_parser.add_argument(
         u'--prompt',
         dest=u'prompt',
         metavar=u'',
         help=u'Prompt format (Default: \\d> ')
 
+    return args_parser
+
+
+def get_parser():
+    parser = initialize()
     return parser
 
-
-parser = initialize()
-
-
-def parse(args):
-    options = parser.parse_args(args)
-    return options

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -2,15 +2,14 @@ import argparse
 import mssqlcli
 import os
 
+from .config import config_location
+
 MSSQL_CLI_USER = u'MSSQL_CLI_USER'
 MSSQL_CLI_PASSWORD = u'MSSQL_CLI_PASSWORD'
 MSSQL_CLI_DATABASE = u'MSSQL_CLI_DATABASE'
 MSSQL_CLI_SERVER = u'MSSQL_CLI_SERVER'
 MSSQL_CLI_ROW_LIMIT = u'MSSQL_CLI_ROW_LIMIT'
 MSSQL_CLI_RC = u'MSSQL_CLI_RC'
-
-# Look at how to get password prompt if it's not set
-# Get the default config
 
 
 def initialize():
@@ -28,10 +27,10 @@ def initialize():
 
     parser.add_argument(
         u'-P', u'--password',
-        dest=u'prompt_passwd',
+        dest=u'password',
         default=os.environ.get(MSSQL_CLI_PASSWORD, None),
         metavar=u'',
-        help=u'Force password prompt')
+        help=u'If not supplied, defaults to value in environment variable MSSQL_CLI_PASSWORD.')
 
     parser.add_argument(
         u'-d', u'--database',
@@ -52,7 +51,6 @@ def initialize():
         dest=u'integrated_auth',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Use integrated authentication on windows.')
 
     parser.add_argument(
@@ -60,12 +58,11 @@ def initialize():
         dest=u'version',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Version of mssql-cli.')
 
     parser.add_argument(
         u'--mssqlclirc',
-        dest=u'mssqlclirc',
+        dest=u'mssqlclirc_file',
         default=os.environ.get(MSSQL_CLI_RC, config_location() + 'config'),
         metavar=u'',
         help=u'Location of mssqlclirc config file.')
@@ -82,7 +79,6 @@ def initialize():
         dest=u'less_chatty',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Skip intro on startup and goodbye on exit.')
 
     parser.add_argument(
@@ -90,7 +86,6 @@ def initialize():
         dest=u'auto_vertical_output',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Automatically switch to vertical output mode if the result is wider than the terminal width.')
 
     parser.add_argument(
@@ -98,7 +93,6 @@ def initialize():
         dest=u'encrypt',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'SQL Server uses SSL encryption for all data if the server has a certificate installed.')
 
     parser.add_argument(
@@ -106,12 +100,11 @@ def initialize():
         dest=u'trust_server_certificate',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'The channel will be encrypted while bypassing walking the certificate chain to validate trust.')
 
     parser.add_argument(
         u'-l', u'--connect-timeout',
-        dest=u'connect_timeout',
+        dest=u'connection_timeout',
         default=0,
         metavar=u'',
         help=u'Time in seconds to wait for a connection to the server before terminating request.')
@@ -127,7 +120,6 @@ def initialize():
         dest=u'multi_subnet_failover',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'If application is connecting to AlwaysOn AG on different subnets, setting this provides faster '
              u'detection and connection to currently active server.')
 
@@ -143,7 +135,6 @@ def initialize():
         dest=u'dac_connection',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Connect to SQL Server using the dedicated administrator connection.')
 
     parser.add_argument(
@@ -151,14 +142,13 @@ def initialize():
         dest=u'enable_sqltoolsservice_logging',
         action=u'store_true',
         default=False,
-        metavar=u'',
         help=u'Enables diagnostic logging for the SqlToolsService.')
 
     parser.add_argument(
         u'--prompt',
         dest=u'prompt',
         metavar=u'',
-        help=u'Prompt format (Default: "{}").'.format(MssqlCli.default_prompt))
+        help=u'Prompt format (Default: \\d> ')
 
     return parser
 
@@ -167,5 +157,5 @@ parser = initialize()
 
 
 def parse(args):
-    options = parser.parse(args)
+    options = parser.parse_args(args)
     return options

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -12,7 +12,7 @@ MSSQL_CLI_ROW_LIMIT = u'MSSQL_CLI_ROW_LIMIT'
 MSSQL_CLI_RC = u'MSSQL_CLI_RC'
 
 
-def initialize():
+def create_parser():
     args_parser = argparse.ArgumentParser(
         prog=u'mssql-cli',
         description=u'Microsoft SQL Server CLI. ' +
@@ -151,9 +151,4 @@ def initialize():
         help=u'Prompt format (Default: \\d> ')
 
     return args_parser
-
-
-def get_parser():
-    parser = initialize()
-    return parser
 

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -1,0 +1,171 @@
+import argparse
+import mssqlcli
+import os
+
+MSSQL_CLI_USER = u'MSSQL_CLI_USER'
+MSSQL_CLI_PASSWORD = u'MSSQL_CLI_PASSWORD'
+MSSQL_CLI_DATABASE = u'MSSQL_CLI_DATABASE'
+MSSQL_CLI_SERVER = u'MSSQL_CLI_SERVER'
+MSSQL_CLI_ROW_LIMIT = u'MSSQL_CLI_ROW_LIMIT'
+MSSQL_CLI_RC = u'MSSQL_CLI_RC'
+
+# Look at how to get password prompt if it's not set
+# Get the default config
+
+
+def initialize():
+    parser = argparse.ArgumentParser(
+        prog=u'mssql-cli',
+        description=u'Microsoft SQL Server CLI. ' +
+        u'Version {}'.format(mssqlcli.__version__))
+
+    parser.add_argument(
+        u'-U', u'--username',
+        dest=u'username',
+        default=os.environ.get(MSSQL_CLI_USER, None),
+        metavar=u'',
+        help=u'Username to connect to the database')
+
+    parser.add_argument(
+        u'-P', u'--password',
+        dest=u'prompt_passwd',
+        default=os.environ.get(MSSQL_CLI_PASSWORD, None),
+        metavar=u'',
+        help=u'Force password prompt')
+
+    parser.add_argument(
+        u'-d', u'--database',
+        dest=u'database',
+        default=os.environ.get(MSSQL_CLI_DATABASE, u'master'),
+        metavar=u'',
+        help=u'database name to connect to.')
+
+    parser.add_argument(
+        u'-S', u'--server',
+        dest=u'server',
+        default=os.environ.get(MSSQL_CLI_SERVER, u'localhost'),
+        metavar=u'',
+        help=u'SQL Server instance name or address.')
+
+    parser.add_argument(
+        u'-I', u'--integrated',
+        dest=u'integrated_auth',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Use integrated authentication on windows.')
+
+    parser.add_argument(
+        u'-v', u'--version',
+        dest=u'version',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Version of mssql-cli.')
+
+    parser.add_argument(
+        u'--mssqlclirc',
+        dest=u'mssqlclirc',
+        default=os.environ.get(MSSQL_CLI_RC, config_location() + 'config'),
+        metavar=u'',
+        help=u'Location of mssqlclirc config file.')
+
+    parser.add_argument(
+        u'--row-limit',
+        dest=u'row_limit',
+        default=os.environ.get(MSSQL_CLI_ROW_LIMIT, None),
+        metavar=u'',
+        help=u'Set threshold for row limit prompt. Use 0 to disable prompt.')
+
+    parser.add_argument(
+        u'--less-chatty',
+        dest=u'less_chatty',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Skip intro on startup and goodbye on exit.')
+
+    parser.add_argument(
+        u'--auto-vertical-output',
+        dest=u'auto_vertical_output',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Automatically switch to vertical output mode if the result is wider than the terminal width.')
+
+    parser.add_argument(
+        u'-N', u'--encrypt',
+        dest=u'encrypt',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'SQL Server uses SSL encryption for all data if the server has a certificate installed.')
+
+    parser.add_argument(
+        u'-C', u'--trust-server-certificate',
+        dest=u'trust_server_certificate',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'The channel will be encrypted while bypassing walking the certificate chain to validate trust.')
+
+    parser.add_argument(
+        u'-l', u'--connect-timeout',
+        dest=u'connect_timeout',
+        default=0,
+        metavar=u'',
+        help=u'Time in seconds to wait for a connection to the server before terminating request.')
+
+    parser.add_argument(
+        u'-K', u'--application-intent',
+        dest=u'application_intent',
+        metavar=u'',
+        help=u'Declares the application workload type when connecting to a database in a SQL Server Availability Group.')
+
+    parser.add_argument(
+        u'-M', u'--multi-subnet-failover',
+        dest=u'multi_subnet_failover',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'If application is connecting to AlwaysOn AG on different subnets, setting this provides faster '
+             u'detection and connection to currently active server.')
+
+    parser.add_argument(
+        u'-a', u'--packet-size',
+        dest=u'packet_size',
+        default=0,
+        metavar=u'',
+        help=u'Size in bytes of the network packets used to communicate with SQL Server.')
+
+    parser.add_argument(
+        u'-A', u'--dac-connection',
+        dest=u'dac_connection',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Connect to SQL Server using the dedicated administrator connection.')
+
+    parser.add_argument(
+        u'--enable-sqltoolsservice-logging',
+        dest=u'enable_sqltoolsservice_logging',
+        action=u'store_true',
+        default=False,
+        metavar=u'',
+        help=u'Enables diagnostic logging for the SqlToolsService.')
+
+    parser.add_argument(
+        u'--prompt',
+        dest=u'prompt',
+        metavar=u'',
+        help=u'Prompt format (Default: "{}").'.format(MssqlCli.default_prompt))
+
+    return parser
+
+
+parser = initialize()
+
+
+def parse(args):
+    options = parser.parse(args)
+    return options

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -549,7 +549,7 @@ class MssqlCompleter(Completer):
         joins = []
         # Iterate over FKs in existing tables to find potential joins
         fks = ((fk, rtbl, rcol) for rtbl, rcols in cols.items()
-               for rcol in rcols for fk in rcol.foreignkeys)
+               for rcol in rcols for fk in rcol.get_foreign_keys)
         col = namedtuple('col', 'schema tbl col')
         for fk, rtbl, rcol in fks:
             right = col(rtbl.schema, rtbl.name, rcol.name)
@@ -614,7 +614,7 @@ class MssqlCompleter(Completer):
                             for t, c in cols if t.ref != lref)
         # For each fk from the left table, generate a join condition if
         # the other table is also in the scope
-        fks = ((fk, lcol.name) for lcol in lcols for fk in lcol.foreignkeys)
+        fks = ((fk, lcol.name) for lcol in lcols for fk in lcol.get_foreign_keys)
         for fk, lcol in fks:
             left = col(ltbl.schema, ltbl.name, lcol)
             child = col(fk.childschema, fk.childtable, fk.childcolumn)

--- a/mssqlcli/packages/special/commands.py
+++ b/mssqlcli/packages/special/commands.py
@@ -21,7 +21,7 @@ def list_databases(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += " where name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\ls', '\\ls[+] [pattern]', 'List schemas.')
@@ -35,7 +35,7 @@ def list_schemas(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += " where name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\lt', '\\lt[+] [pattern]', 'List tables.')
@@ -49,7 +49,7 @@ def list_tables(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += "and table_name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\lv', '\\lv[+] [pattern]', 'List views.')
@@ -64,7 +64,7 @@ def list_views(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += "and table_name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\li', '\\li[+] [pattern]', 'List indexes.')
@@ -103,7 +103,7 @@ ORDER BY
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\lf', '\\lf[+] [pattern]', 'List functions.')
@@ -126,7 +126,7 @@ WHERE type_desc like '%function%' {pattern}
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\sf', '\\sf FUNCNAME', 'Show a function\'s definition.')
@@ -143,7 +143,7 @@ INNER JOIN sys.objects o
 WHERE type_desc like '%function%' and name like '{0}'
 '''.format(pattern)
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('describe', 'DESCRIBE OBJECT', '', hidden=True, case_sensitive=False)
@@ -154,7 +154,7 @@ def describe_object(mssqlcliclient, pattern, verbose):
         return []
 
     base_query = 'exec sp_help [{0}]'.format(pattern)
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\ll', '\\ll[+] [pattern]', 'List logins and associated roles.')
@@ -186,7 +186,7 @@ ORDER BY name, type_desc
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement(base_query)
+    return mssqlcliclient.execute_query(base_query)
 
 
 @special_command('\\n', '\\n[+] [name] [param1 param2 ...]', 'List or execute named queries.')
@@ -206,7 +206,7 @@ def execute_named_query(mssqlcliclient, pattern, **__):
         if arg_error:
             return [(None, None, arg_error, None, False)]
         else:
-            return mssqlcliclient.execute_multi_statement(query)
+            return mssqlcliclient.execute_query(query)
 
 
 @special_command('\\sn', '\\sn name query', 'Save a named query.')

--- a/mssqlcli/packages/special/commands.py
+++ b/mssqlcli/packages/special/commands.py
@@ -21,7 +21,7 @@ def list_databases(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += " where name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\ls', '\\ls[+] [pattern]', 'List schemas.')
@@ -35,7 +35,7 @@ def list_schemas(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += " where name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\lt', '\\lt[+] [pattern]', 'List tables.')
@@ -49,7 +49,7 @@ def list_tables(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += "and table_name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\lv', '\\lv[+] [pattern]', 'List views.')
@@ -64,7 +64,7 @@ def list_views(mssqlcliclient, pattern, verbose):
     if pattern:
         base_query += "and table_name like '%{0}%'".format(pattern)
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\li', '\\li[+] [pattern]', 'List indexes.')
@@ -103,7 +103,7 @@ ORDER BY
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\lf', '\\lf[+] [pattern]', 'List functions.')
@@ -126,7 +126,7 @@ WHERE type_desc like '%function%' {pattern}
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\sf', '\\sf FUNCNAME', 'Show a function\'s definition.')
@@ -143,7 +143,7 @@ INNER JOIN sys.objects o
 WHERE type_desc like '%function%' and name like '{0}'
 '''.format(pattern)
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('describe', 'DESCRIBE OBJECT', '', hidden=True, case_sensitive=False)
@@ -154,7 +154,7 @@ def describe_object(mssqlcliclient, pattern, verbose):
         return []
 
     base_query = 'exec sp_help [{0}]'.format(pattern)
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\ll', '\\ll[+] [pattern]', 'List logins and associated roles.')
@@ -186,7 +186,7 @@ ORDER BY name, type_desc
     else:
         base_query = base_query.format(pattern='')
 
-    return mssqlcliclient.execute_multi_statement_single_batch(base_query)
+    return mssqlcliclient.execute_multi_statement(base_query)
 
 
 @special_command('\\n', '\\n[+] [name] [param1 param2 ...]', 'List or execute named queries.')
@@ -206,7 +206,7 @@ def execute_named_query(mssqlcliclient, pattern, **__):
         if arg_error:
             return [(None, None, arg_error, None, False)]
         else:
-            return mssqlcliclient.execute_multi_statement_single_batch(query)
+            return mssqlcliclient.execute_multi_statement(query)
 
 
 @special_command('\\sn', '\\sn name query', 'Save a named query.')

--- a/mssqlcli/sqltoolsclient.py
+++ b/mssqlcli/sqltoolsclient.py
@@ -1,8 +1,3 @@
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for license information.
-# --------------------------------------------------------------------------------------------
-
 import logging
 import subprocess
 import io
@@ -23,6 +18,9 @@ class SqlToolsClient(object):
     """
         Create sql tools service requests.
     """
+    CONNECTION_REQUEST = u'connection_request'
+    QUERY_EXECUTE_STRING_REQUEST = u'query_execute_string_request'
+    QUERY_SUBSET_REQUEST = u'query_subset_request'
 
     def __init__(self, input_stream=None, output_stream=None, enable_logging=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ def get_timestamped_version(version):
 
 install_requirements = [
     'click >= 4.1',
+    'argparse >= 1.4.0',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased.
     'prompt_toolkit>=1.0.10,<1.1.0',
     'sqlparse >=0.2.2,<0.3.0',

--- a/tests/features/steps/auto_vertical.py
+++ b/tests/features/steps/auto_vertical.py
@@ -9,7 +9,7 @@ import wrappers
 
 @when('we run dbcli with {arg}')
 def step_run_cli_with_arg(context, arg):
-    wrappers.run_cli(context, run_args=arg.split('='))
+    wrappers.run(context, run_args=arg.split('='))
 
 
 @when('we execute a small query')

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -14,7 +14,7 @@ import wrappers
 
 @when('we run dbcli')
 def step_run_cli(context):
-    wrappers.run_cli(context)
+    wrappers.run(context)
 
 
 @when('we wait for prompt')

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -9,10 +9,11 @@ from mssqlcli.mssqlclioptionsparser import get_parser
 def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tools_client=None, **additional_params):
     """
     Retrieve a mssqlcliclient connection.
+    :param options: options
     :param owner_uri: string
     :param connect: boolean
     :param sql_tools_client: SqlToolsClient
-    :param options: options
+    :param additional_params: kwargs
     :return: MssqlCliClient
     """
     try:
@@ -35,13 +36,14 @@ def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tool
 def create_mssql_cli_options(**nondefault_options):
 
     parser = get_parser()
+
     default_mssql_cli_options = parser.parse_args('')
 
     if nondefault_options:
         updateable_mssql_cli_options = vars(default_mssql_cli_options)
         for option in nondefault_options.keys():
             if option not in updateable_mssql_cli_options.keys():
-                raise Exception('Invalid mssql cli option specified {}'.format(option))
+                raise Exception('Invalid mssql-cli option specified: {}'.format(option))
 
             updateable_mssql_cli_options[option] = nondefault_options.get(option)
 
@@ -57,11 +59,11 @@ def run_and_return_string_from_formatter(client, sql, join=False, expanded=False
     :param sql: string
     :param join: boolean
     :param expanded: boolean
-    :return:
+    :return: formatted string
     """
 
     for rows, col, message, query, is_error in client.execute_single_statement(sql):
-        settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g',
+        settings = OutputSettings(table_format='mssql', dcmlfmt='d', floatfmt='g',
                                   expanded=expanded)
         formatted = format_output(None, rows, col, message, settings)
         if join:

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -33,7 +33,7 @@ def create_mssql_cli_client(owner_uri=None, connect=True):
                                                          extra_string_param=u'stringparam',
                                                          extra_int_param=5)
         if connect:
-            mssql_cli_client.connect()
+            mssql_cli_client.connect_to_database()
         return mssql_cli_client
     except Exception as e:
         print('Connection failed')

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -1,43 +1,53 @@
-import os
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
+
 from mssqlcli.main import format_output, OutputSettings
+from mssqlcli.mssqlclioptionsparser import get_parser
+from argparse import Namespace
 
 
-def create_mssql_cli_client(owner_uri=None, connect=True):
+def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tools_client=None, **additional_params):
     """
     Retrieve a mssqlcliclient connection.
     :param owner_uri: string
     :param connect: boolean
-    :param server_name: string
-    :param database_name: string
+    :param sql_tools_client: SqlToolsClient
+    :param options: options
     :return: MssqlCliClient
     """
     try:
-        server_name = os.environ['MSSQL_CLI_SERVER']
-        database_name = os.environ['MSSQL_CLI_DATABASE']
-        user_name = os.environ['MSSQL_CLI_USER']
-        password = os.environ['MSSQL_CLI_PASSWORD']
+        sql_tools_client = sql_tools_client if sql_tools_client else sqltoolsclient.SqlToolsClient()
+        mssql_cli_options = options if options else create_mssql_cli_options()
 
-        if not server_name or not database_name or not user_name or not password:
-            raise Exception('Environment variables for running tests not found.')
-
-        sql_tools_client = sqltoolsclient.SqlToolsClient()
-        mssql_cli_client = mssqlcliclient.MssqlCliClient(sql_tools_client,
-                                                         server_name,
-                                                         user_name,
-                                                         password,
-                                                         database=database_name,
+        mssql_cli_client = mssqlcliclient.MssqlCliClient(mssql_cli_options,
+                                                         sql_tools_client,
                                                          owner_uri=owner_uri,
-                                                         extra_bool_param=True,
-                                                         extra_string_param=u'stringparam',
-                                                         extra_int_param=5)
+                                                         **additional_params)
+
         if connect:
             mssql_cli_client.connect_to_database()
         return mssql_cli_client
     except Exception as e:
         print('Connection failed')
         raise e
+
+
+def create_mssql_cli_options(**nondefault_options):
+
+    parser = get_parser()
+    default_mssql_cli_options = parser.parse_args('')
+
+    if nondefault_options:
+        updateable_mssql_cli_options = vars(default_mssql_cli_options)
+        for option in nondefault_options.keys():
+            if option not in updateable_mssql_cli_options.keys():
+                raise Exception('Invalid mssql cli option specified {}'.format(option))
+
+            updateable_mssql_cli_options[option] = nondefault_options.get(option)
+
+        return Namespace(**updateable_mssql_cli_options)
+
+    return default_mssql_cli_options
 
 
 def run_and_return_string_from_formatter(client, sql, join=False, expanded=False):

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -63,7 +63,7 @@ def run_and_return_string_from_formatter(client, sql, join=False, expanded=False
     """
 
     for rows, col, message, query, is_error in client.execute_single_statement(sql):
-        settings = OutputSettings(table_format='mssql', dcmlfmt='d', floatfmt='g',
+        settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g',
                                   expanded=expanded)
         formatted = format_output(None, rows, col, message, settings)
         if join:

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -3,7 +3,7 @@ import mssqlcli.mssqlcliclient as mssqlcliclient
 
 from argparse import Namespace
 from mssqlcli.main import format_output, OutputSettings
-from mssqlcli.mssqlclioptionsparser import get_parser
+from mssqlcli.mssqlclioptionsparser import create_parser
 
 
 def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tools_client=None, **additional_params):
@@ -35,7 +35,7 @@ def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tool
 
 def create_mssql_cli_options(**nondefault_options):
 
-    parser = get_parser()
+    parser = create_parser()
 
     default_mssql_cli_options = parser.parse_args('')
 
@@ -62,7 +62,7 @@ def run_and_return_string_from_formatter(client, sql, join=False, expanded=False
     :return: formatted string
     """
 
-    for rows, col, message, query, is_error in client.execute_single_statement(sql):
+    for rows, col, message, query, is_error in client.execute_query(sql):
         settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g',
                                   expanded=expanded)
         formatted = format_output(None, rows, col, message, settings)

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -51,7 +51,7 @@ def run_and_return_string_from_formatter(client, sql, join=False, expanded=False
     :return:
     """
 
-    for rows, col, message, query, is_error in client.execute_single_batch_query(sql):
+    for rows, col, message, query, is_error in client.execute_single_statement(sql):
         settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g',
                                   expanded=expanded)
         formatted = format_output(None, rows, col, message, settings)

--- a/tests/mssqlutils.py
+++ b/tests/mssqlutils.py
@@ -1,9 +1,9 @@
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
 
+from argparse import Namespace
 from mssqlcli.main import format_output, OutputSettings
 from mssqlcli.mssqlclioptionsparser import get_parser
-from argparse import Namespace
 
 
 def create_mssql_cli_client(options=None, owner_uri=None, connect=True, sql_tools_client=None, **additional_params):
@@ -57,7 +57,6 @@ def run_and_return_string_from_formatter(client, sql, join=False, expanded=False
     :param sql: string
     :param join: boolean
     :param expanded: boolean
-    :param exception_formatter: boolean
     :return:
     """
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
 import os
-from mssqlutils import create_mssql_cli_client, shutdown, run_and_return_string_from_formatter
+from mssqlutils import create_mssql_cli_options, create_mssql_cli_client, shutdown, run_and_return_string_from_formatter
 from time import sleep
-import pytest
+
 from mssqlcli.main import (
     format_output, MssqlCli, OutputSettings
 )
@@ -110,7 +110,8 @@ def test_format_output_auto_expand():
 def test_missing_rc_dir(tmpdir):
     try:
         rcfile = str(tmpdir.join("subdir").join("rcfile"))
-        mssqlcli = MssqlCli(mssqlclirc_file=rcfile)
+        mssql_cli_options = create_mssql_cli_options(mssqlclirc_file=rcfile)
+        mssqlcli = MssqlCli(mssql_cli_options)
         assert os.path.exists(rcfile)
     finally:
         mssqlcli.sqltoolsclient.shutdown()

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -84,7 +84,7 @@ class MssqlCliClientTests(unittest.TestCase):
                 select 3, 'Night'
             """
 
-            for rows, col, message, query, is_error in client.execute_single_batch_query(test_query):
+            for rows, col, message, query, is_error in client.execute_single_statement(test_query):
                 self.assertTrue(len(rows), 3)
                 self.assertTrue(query, test_query)
         finally:
@@ -113,24 +113,24 @@ class MssqlCliClientTests(unittest.TestCase):
         """
         try:
             client = create_mssql_cli_client()
-            list(client.execute_single_batch_query('CREATE TABLE tabletest1 (a int, b varchar(25));'))
-            list(client.execute_single_batch_query('CREATE TABLE tabletest2 (x int, y varchar(25), z bit);'))
-            list(client.execute_single_batch_query('CREATE VIEW viewtest as SELECT a from tabletest1;'))
-            list(client.execute_single_batch_query('CREATE SCHEMA schematest;'))
-            list(client.execute_single_batch_query('CREATE TABLE schematest.tabletest1 (a int);'))
+            list(client.execute_single_statement('CREATE TABLE tabletest1 (a int, b varchar(25));'))
+            list(client.execute_single_statement('CREATE TABLE tabletest2 (x int, y varchar(25), z bit);'))
+            list(client.execute_single_statement('CREATE VIEW viewtest as SELECT a from tabletest1;'))
+            list(client.execute_single_statement('CREATE SCHEMA schematest;'))
+            list(client.execute_single_statement('CREATE TABLE schematest.tabletest1 (a int);'))
 
-            assert ('schematest', 'tabletest1') in set(client.tables())
-            assert ('dbo', 'viewtest') in set(client.views())
-            assert ('schematest', 'tabletest1', 'a', 'int', 'NULL') in set(client.table_columns())
-            assert ('dbo', 'viewtest', 'a', 'int', 'NULL') in set(client.view_columns())
-            assert 'schematest' in client.schemas()
+            assert ('schematest', 'tabletest1') in set(client.get_tables())
+            assert ('dbo', 'viewtest') in set(client.get_views())
+            assert ('schematest', 'tabletest1', 'a', 'int', 'NULL') in set(client.get_table_columns())
+            assert ('dbo', 'viewtest', 'a', 'int', 'NULL') in set(client.get_view_columns())
+            assert 'schematest' in client.get_schemas()
 
         finally:
-            list(client.execute_single_batch_query('DROP TABLE tabletest1;'))
-            list(client.execute_single_batch_query('DROP TABLE tabletest2;'))
-            list(client.execute_single_batch_query('DROP VIEW viewtest IF EXISTS;'))
-            list(client.execute_single_batch_query('DROP TABLE schematest.tabletest1;'))
-            list(client.execute_single_batch_query('DROP SCHEMA schematest;'))
+            list(client.execute_single_statement('DROP TABLE tabletest1;'))
+            list(client.execute_single_statement('DROP TABLE tabletest2;'))
+            list(client.execute_single_statement('DROP VIEW viewtest IF EXISTS;'))
+            list(client.execute_single_statement('DROP TABLE schematest.tabletest1;'))
+            list(client.execute_single_statement('DROP SCHEMA schematest;'))
             shutdown(client)
 
     def test_mssqlcliclient_reset_connection(self):
@@ -153,21 +153,21 @@ class MssqlCliClientTests(unittest.TestCase):
             multi_statement_query2 = u"select 1; select 'foo' from teapot;"
             multi_statement_query3 = u"select 'foo' from teapot; select 2;"
             for rows, col, message, query, is_error in \
-                client.execute_multi_statement_single_batch(multi_statement_query):
+                client.execute_multi_statement(multi_statement_query):
                 if query == u"select 'Morning' as [Name] UNION ALL select 'Evening'":
                     self.assertTrue(len(rows), 2)
                 else:
                     self.assertTrue(len(rows), 1)
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement_single_batch(multi_statement_query2):
+                    client.execute_multi_statement(multi_statement_query2):
                 if query == u"select 1":
                     self.assertTrue(len(rows) == 1)
                 else:
                     self.assertTrue(is_error)
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement_single_batch(multi_statement_query3):
+                    client.execute_multi_statement(multi_statement_query3):
                 if query == u"select 2":
                     self.assertTrue(len(rows) == 1)
                 else:
@@ -191,13 +191,13 @@ class MssqlCliClientTests(unittest.TestCase):
             exec_stored_proc = u"EXEC sp_mssqlcli_multiple_results"
             del_stored_proc = u"DROP PROCEDURE sp_mssqlcli_multiple_results"
 
-            list(client.execute_single_batch_query(create_stored_proc))
+            list(client.execute_single_statement(create_stored_proc))
             row_counts = []
-            for rows, columns, message, query, is_error in client.execute_single_batch_query(exec_stored_proc):
+            for rows, columns, message, query, is_error in client.execute_single_statement(exec_stored_proc):
                 row_counts.append(len(rows))
             self.assertTrue(row_counts[0] == 2)
             self.assertTrue(row_counts[1] == 3)
-            list(client.execute_single_batch_query(del_stored_proc))
+            list(client.execute_single_statement(del_stored_proc))
         finally:
             shutdown(client)
 

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -3,10 +3,10 @@ import os
 import io
 import unittest
 import mssqlcli.sqltoolsclient as sqltoolsclient
-import mssqlcli.mssqlcliclient as mssqlcliclient
 
 from mssqlcli.jsonrpc.jsonrpcclient import JsonRpcWriter
 from mssqlutils import create_mssql_cli_options, create_mssql_cli_client, shutdown
+from mssqlcli.main import MssqlCli
 from time import sleep
 
 
@@ -82,7 +82,7 @@ class MssqlCliClientTests(unittest.TestCase):
                 select 3, 'Night'
             """
 
-            for rows, col, message, query, is_error in client.execute_single_statement(test_query):
+            for rows, col, message, query, is_error in client.execute_query(test_query):
                 self.assertTrue(len(rows), 3)
                 self.assertTrue(query, test_query)
         finally:
@@ -111,11 +111,11 @@ class MssqlCliClientTests(unittest.TestCase):
         """
         try:
             client = create_mssql_cli_client()
-            list(client.execute_single_statement('CREATE TABLE tabletest1 (a int, b varchar(25));'))
-            list(client.execute_single_statement('CREATE TABLE tabletest2 (x int, y varchar(25), z bit);'))
-            list(client.execute_single_statement('CREATE VIEW viewtest as SELECT a from tabletest1;'))
-            list(client.execute_single_statement('CREATE SCHEMA schematest;'))
-            list(client.execute_single_statement('CREATE TABLE schematest.tabletest1 (a int);'))
+            list(client.execute_query('CREATE TABLE tabletest1 (a int, b varchar(25));'))
+            list(client.execute_query('CREATE TABLE tabletest2 (x int, y varchar(25), z bit);'))
+            list(client.execute_query('CREATE VIEW viewtest as SELECT a from tabletest1;'))
+            list(client.execute_query('CREATE SCHEMA schematest;'))
+            list(client.execute_query('CREATE TABLE schematest.tabletest1 (a int);'))
 
             assert ('schematest', 'tabletest1') in set(client.get_tables())
             assert ('dbo', 'viewtest') in set(client.get_views())
@@ -124,11 +124,11 @@ class MssqlCliClientTests(unittest.TestCase):
             assert 'schematest' in client.get_schemas()
 
         finally:
-            list(client.execute_single_statement('DROP TABLE tabletest1;'))
-            list(client.execute_single_statement('DROP TABLE tabletest2;'))
-            list(client.execute_single_statement('DROP VIEW viewtest IF EXISTS;'))
-            list(client.execute_single_statement('DROP TABLE schematest.tabletest1;'))
-            list(client.execute_single_statement('DROP SCHEMA schematest;'))
+            list(client.execute_query('DROP TABLE tabletest1;'))
+            list(client.execute_query('DROP TABLE tabletest2;'))
+            list(client.execute_query('DROP VIEW viewtest IF EXISTS;'))
+            list(client.execute_query('DROP TABLE schematest.tabletest1;'))
+            list(client.execute_query('DROP SCHEMA schematest;'))
             shutdown(client)
 
     def test_mssqlcliclient_reset_connection(self):
@@ -136,10 +136,11 @@ class MssqlCliClientTests(unittest.TestCase):
             Verify if the MssqlCliClient can successfully reset its connection
         """
         try:
-            client = create_mssql_cli_client()
-            mssqlcliclient.reset_connection_and_clients(client.sql_tools_client, client)
+            default_options = create_mssql_cli_options()
+            mssqlcli = MssqlCli(default_options)
+            mssqlcli.reset_connection()
         finally:
-            shutdown(client)
+            shutdown(mssqlcli.mssqlcliclient_main)
 
     def test_mssqlcliclient_multiple_statement(self):
         """
@@ -150,22 +151,21 @@ class MssqlCliClientTests(unittest.TestCase):
             multi_statement_query = u"select 'Morning' as [Name] UNION ALL select 'Evening'; select 1;"
             multi_statement_query2 = u"select 1; select 'foo' from teapot;"
             multi_statement_query3 = u"select 'foo' from teapot; select 2;"
-            for rows, col, message, query, is_error in \
-                client.execute_multi_statement(multi_statement_query):
+            for rows, col, message, query, is_error in client.execute_query(multi_statement_query):
                 if query == u"select 'Morning' as [Name] UNION ALL select 'Evening'":
                     self.assertTrue(len(rows), 2)
                 else:
                     self.assertTrue(len(rows), 1)
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement(multi_statement_query2):
+                    client.execute_query(multi_statement_query2):
                 if query == u"select 1":
                     self.assertTrue(len(rows) == 1)
                 else:
                     self.assertTrue(is_error)
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement(multi_statement_query3):
+                    client.execute_query(multi_statement_query3):
                 if query == u"select 2":
                     self.assertTrue(len(rows) == 1)
                 else:
@@ -189,13 +189,13 @@ class MssqlCliClientTests(unittest.TestCase):
             exec_stored_proc = u"EXEC sp_mssqlcli_multiple_results"
             del_stored_proc = u"DROP PROCEDURE sp_mssqlcli_multiple_results"
 
-            list(client.execute_single_statement(create_stored_proc))
+            list(client.execute_query(create_stored_proc))
             row_counts = []
-            for rows, columns, message, query, is_error in client.execute_single_statement(exec_stored_proc):
+            for rows, columns, message, query, is_error in client.execute_query(exec_stored_proc):
                 row_counts.append(len(rows))
             self.assertTrue(row_counts[0] == 2)
             self.assertTrue(row_counts[1] == 3)
-            list(client.execute_single_statement(del_stored_proc))
+            list(client.execute_query(del_stored_proc))
         finally:
             shutdown(client)
 

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -7,7 +7,7 @@ from time import sleep
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
 from mssqlcli.jsonrpc.jsonrpcclient import JsonRpcWriter
-from mssqlutils import create_mssql_cli_client, shutdown
+from mssqlutils import create_mssql_cli_options, create_mssql_cli_client, shutdown
 
 
 # All tests apart from test_mssqlcliclient_request_response require a live connection to an
@@ -49,17 +49,15 @@ class MssqlCliClientTests(unittest.TestCase):
             # issue24262
             sleep(0.5)
 
-        self.client = mssqlcliclient.MssqlCliClient(self.sql_tools_client,
-                                                    u'bro-hb',
-                                                    u'*',
-                                                    u'*',
-                                                    authentication_type=u'Integrated',
-                                                    database=u'AdventureWorks2014',
-                                                    owner_uri=u'connectionservicetest',
-                                                    extra_bool_param=True,
-                                                    extra_string_param=u'stringparam',
-                                                    extra_int_param=5)
-        self.client.sql_tools_client.shutdown()
+        self.mssql_cli_options = create_mssql_cli_options(integrated_auth=True)
+        self.mssql_cli_client = create_mssql_cli_client(self.mssql_cli_options,
+                                                        owner_uri=u'connectionservicetest',
+                                                        sql_tools_client=self.sql_tools_client,
+                                                        extra_bool_param=True,
+                                                        extra_string_param=u'stringparam',
+                                                        extra_int_param=5)
+
+        self.mssql_cli_client.shutdown()
 
     def test_connection(self):
         """

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -2,12 +2,12 @@
 import os
 import io
 import unittest
-from time import sleep
-
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
+
 from mssqlcli.jsonrpc.jsonrpcclient import JsonRpcWriter
 from mssqlutils import create_mssql_cli_options, create_mssql_cli_client, shutdown
+from time import sleep
 
 
 # All tests apart from test_mssqlcliclient_request_response require a live connection to an

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -138,7 +138,7 @@ class MssqlCliClientTests(unittest.TestCase):
         try:
             default_options = create_mssql_cli_options()
             mssqlcli = MssqlCli(default_options)
-            mssqlcli.reset_connection()
+            mssqlcli.reset()
         finally:
             shutdown(mssqlcli.mssqlcliclient_main)
 

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -32,14 +32,14 @@ def test_set_row_limit():
     assert result is True
 
 
-#def test_no_limit():
-#    cli_options = create_mssql_cli_options(row_limit=0)
-#    cli = MssqlCli(cli_options)
-#    assert cli.row_limit is 0
-#    stmt = "SELECT * FROM students"
-#
-#    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
-#    assert result is False
+def test_no_limit():
+    cli_options = create_mssql_cli_options(row_limit=0)
+    cli = MssqlCli(cli_options)
+    assert cli.row_limit is 0
+    stmt = "SELECT * FROM students"
+
+    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
+    assert result is False
 
 
 def test_row_limit_on_non_select():

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -1,14 +1,18 @@
 from mssqlcli.main import MssqlCli
+from mssqlutils import create_mssql_cli_options
 
-DEFAULT = MssqlCli().row_limit
+
+DEFAULT_OPTIONS = create_mssql_cli_options()
+DEFAULT = MssqlCli(DEFAULT_OPTIONS).row_limit
 LIMIT = DEFAULT + 1000
 
 low_count = 1
 over_default = DEFAULT + 1
 over_limit = LIMIT + 1
 
+
 def test_default_row_limit():
-    cli = MssqlCli()
+    cli = MssqlCli(DEFAULT_OPTIONS)
     stmt = "SELECT * FROM students"
     result = cli._should_show_limit_prompt(stmt, ['row']*low_count)
     assert result is False
@@ -18,7 +22,8 @@ def test_default_row_limit():
 
 
 def test_set_row_limit():
-    cli = MssqlCli(row_limit=LIMIT)
+    cli_options = create_mssql_cli_options(row_limit=LIMIT)
+    cli = MssqlCli(cli_options)
     stmt = "SELECT * FROM students"
     result = cli._should_show_limit_prompt(stmt, ['row']*over_default)
     assert result is False
@@ -27,20 +32,25 @@ def test_set_row_limit():
     assert result is True
 
 
-def test_no_limit():
-    cli = MssqlCli(row_limit=0)
-    stmt = "SELECT * FROM students"
-
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
-    assert result is False
+#def test_no_limit():
+#    cli_options = create_mssql_cli_options(row_limit=0)
+#    cli = MssqlCli(cli_options)
+#    assert cli.row_limit is 0
+#    stmt = "SELECT * FROM students"
+#
+#    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
+#    assert result is False
 
 
 def test_row_limit_on_non_select():
-    cli = MssqlCli()
+    cli = MssqlCli(DEFAULT_OPTIONS)
     stmt = "UPDATE students set name='Boby'"
     result = cli._should_show_limit_prompt(stmt, None)
     assert result is False
 
-    cli = MssqlCli(row_limit=0)
+    cli_options = create_mssql_cli_options(row_limit=0)
+    assert cli_options.row_limit is 0
+    cli = MssqlCli(cli_options)
     result = cli._should_show_limit_prompt(stmt, ['row']*over_default)
+    assert cli.row_limit is 0
     assert result is False

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -21,15 +21,15 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             # create the database objects to test upon
             client = create_mssql_cli_client()
-            list(client.execute_single_statement('CREATE DATABASE {0};'.format(cls.database)))
-            list(client.execute_single_statement('CREATE TABLE {0} (a int, b varchar(25));'.format(cls.table1)))
-            list(client.execute_single_statement('CREATE TABLE {0} (x int, y varchar(25), z bit);'.format(cls.table2)))
-            list(client.execute_single_statement('CREATE VIEW {0} as SELECT a from {1};'.format(cls.view, cls.table1)))
-            list(client.execute_single_statement('CREATE SCHEMA {0};'.format(cls.schema)))
-            list(client.execute_single_statement('CREATE INDEX {0} ON {1} (x);'.format(cls.index, cls.table2)))
-            list(client.execute_single_statement('CREATE FUNCTION {0}() RETURNS TABLE AS RETURN (select 1 as number);'
-                                                 .format(cls.function)))
-            list(client.execute_single_statement('CREATE LOGIN {0} WITH PASSWORD=\'yoloC123445!\''.format(cls.login)))
+            list(client.execute_query('CREATE DATABASE {0};'.format(cls.database)))
+            list(client.execute_query('CREATE TABLE {0} (a int, b varchar(25));'.format(cls.table1)))
+            list(client.execute_query('CREATE TABLE {0} (x int, y varchar(25), z bit);'.format(cls.table2)))
+            list(client.execute_query('CREATE VIEW {0} as SELECT a from {1};'.format(cls.view, cls.table1)))
+            list(client.execute_query('CREATE SCHEMA {0};'.format(cls.schema)))
+            list(client.execute_query('CREATE INDEX {0} ON {1} (x);'.format(cls.index, cls.table2)))
+            list(client.execute_query('CREATE FUNCTION {0}() RETURNS TABLE AS RETURN (select 1 as number);'
+                                      .format(cls.function)))
+            list(client.execute_query('CREATE LOGIN {0} WITH PASSWORD=\'yoloC123445!\''.format(cls.login)))
         finally:
             shutdown(client)
 
@@ -38,14 +38,14 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             # delete the database objects created
             client = create_mssql_cli_client()
-            list(client.execute_single_statement('DROP DATABASE {0};'.format(cls.database)))
-            list(client.execute_single_statement('DROP INDEX {0} ON {1};'.format(cls.index, cls.table2)))
-            list(client.execute_single_statement('DROP TABLE {0};'.format(cls.table1)))
-            list(client.execute_single_statement('DROP TABLE {0};'.format(cls.table2)))
-            list(client.execute_single_statement('DROP VIEW {0};'.format(cls.view)))
-            list(client.execute_single_statement('DROP SCHEMA {0};'.format(cls.schema)))
-            list(client.execute_single_statement('DROP FUNCTION {0}'.format(cls.function)))
-            list(client.execute_single_statement('DROP LOGIN {0}'.format(cls.login)))
+            list(client.execute_query('DROP DATABASE {0};'.format(cls.database)))
+            list(client.execute_query('DROP INDEX {0} ON {1};'.format(cls.index, cls.table2)))
+            list(client.execute_query('DROP TABLE {0};'.format(cls.table1)))
+            list(client.execute_query('DROP TABLE {0};'.format(cls.table2)))
+            list(client.execute_query('DROP VIEW {0};'.format(cls.view)))
+            list(client.execute_query('DROP SCHEMA {0};'.format(cls.schema)))
+            list(client.execute_query('DROP FUNCTION {0}'.format(cls.function)))
+            list(client.execute_query('DROP LOGIN {0}'.format(cls.login)))
         finally:
             shutdown(client)
 
@@ -81,7 +81,7 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             client = create_mssql_cli_client()
             for rows, col, message, query, is_error in \
-                client.execute_multi_statement('\\sf {0}'.format(self.function)):
+                client.execute_query('\\sf {0}'.format(self.function)):
                     self.assertTrue(len(rows) == 1)
                     self.assertTrue(len(col) == 1)
         finally:
@@ -92,7 +92,7 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
             result_set_count = 0
             for rows, col, message, query, is_error in \
-                client.execute_multi_statement('\\d {0}'.format(self.function)):
+                client.execute_query('\\d {0}'.format(self.function)):
                     result_set_count += 1
 
             self.assertTrue(result_set_count == 2)
@@ -104,28 +104,28 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
 
             # Save named queries
-            list(client.execute_multi_statement('\\sn test123 select 1'))
-            list(client.execute_multi_statement('\\sn test234 select 2'))
+            list(client.execute_query('\\sn test123 select 1'))
+            list(client.execute_query('\\sn test234 select 2'))
 
             # List named queries
-            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n'):
+            for rows, col, message, sql, is_error in client.execute_query('\\n'):
                 self.assertTrue(len(rows) >= 2)
                 num_queries = len(rows)
 
             # Execute named query created above
-            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n test123'):
+            for rows, col, message, sql, is_error in client.execute_query('\\n test123'):
                 self.assertTrue(len(rows) == 1)
                 self.assertTrue(len(col) == 1)
 
             # Delete a named query that was created
-            list(client.execute_multi_statement('\\dn test123'))
+            list(client.execute_query('\\dn test123'))
 
             # Number of named queries should have reduced by 1
-            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n'):
+            for rows, col, message, sql, is_error in client.execute_query('\\n'):
                 self.assertTrue(num_queries-1 == len(rows))
 
             # Clean up the second named query created
-            list(client.execute_multi_statement('\\dn test234'))
+            list(client.execute_query('\\dn test234'))
 
         finally:
             shutdown(client)
@@ -144,14 +144,14 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement(command):
+                    client.execute_query(command):
                 self.assertTrue(len(rows) >= min_rows_expected)
                 self.assertTrue(len(col) == cols_expected)
 
             # execute with pattern and verbose
             command = command + "+ " + pattern
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement(command):
+                    client.execute_query(command):
                 self.assertTrue(len(rows) == rows_expected_pattern_query)
                 self.assertTrue(len(col) == cols_expected_verbose)
         finally:

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -21,15 +21,15 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             # create the database objects to test upon
             client = create_mssql_cli_client()
-            list(client.execute_single_batch_query('CREATE DATABASE {0};'.format(cls.database)))
-            list(client.execute_single_batch_query('CREATE TABLE {0} (a int, b varchar(25));'.format(cls.table1)))
-            list(client.execute_single_batch_query('CREATE TABLE {0} (x int, y varchar(25), z bit);'.format(cls.table2)))
-            list(client.execute_single_batch_query('CREATE VIEW {0} as SELECT a from {1};'.format(cls.view, cls.table1)))
-            list(client.execute_single_batch_query('CREATE SCHEMA {0};'.format(cls.schema)))
-            list(client.execute_single_batch_query('CREATE INDEX {0} ON {1} (x);'.format(cls.index, cls.table2)))
-            list(client.execute_single_batch_query('CREATE FUNCTION {0}() RETURNS TABLE AS RETURN (select 1 as number);'
-                                                   .format(cls.function)))
-            list(client.execute_single_batch_query('CREATE LOGIN {0} WITH PASSWORD=\'yoloC123445!\''.format(cls.login)))
+            list(client.execute_single_statement('CREATE DATABASE {0};'.format(cls.database)))
+            list(client.execute_single_statement('CREATE TABLE {0} (a int, b varchar(25));'.format(cls.table1)))
+            list(client.execute_single_statement('CREATE TABLE {0} (x int, y varchar(25), z bit);'.format(cls.table2)))
+            list(client.execute_single_statement('CREATE VIEW {0} as SELECT a from {1};'.format(cls.view, cls.table1)))
+            list(client.execute_single_statement('CREATE SCHEMA {0};'.format(cls.schema)))
+            list(client.execute_single_statement('CREATE INDEX {0} ON {1} (x);'.format(cls.index, cls.table2)))
+            list(client.execute_single_statement('CREATE FUNCTION {0}() RETURNS TABLE AS RETURN (select 1 as number);'
+                                                 .format(cls.function)))
+            list(client.execute_single_statement('CREATE LOGIN {0} WITH PASSWORD=\'yoloC123445!\''.format(cls.login)))
         finally:
             shutdown(client)
 
@@ -38,14 +38,14 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             # delete the database objects created
             client = create_mssql_cli_client()
-            list(client.execute_single_batch_query('DROP DATABASE {0};'.format(cls.database)))
-            list(client.execute_single_batch_query('DROP INDEX {0} ON {1};'.format(cls.index, cls.table2)))
-            list(client.execute_single_batch_query('DROP TABLE {0};'.format(cls.table1)))
-            list(client.execute_single_batch_query('DROP TABLE {0};'.format(cls.table2)))
-            list(client.execute_single_batch_query('DROP VIEW {0};'.format(cls.view)))
-            list(client.execute_single_batch_query('DROP SCHEMA {0};'.format(cls.schema)))
-            list(client.execute_single_batch_query('DROP FUNCTION {0}'.format(cls.function)))
-            list(client.execute_single_batch_query('DROP LOGIN {0}'.format(cls.login)))
+            list(client.execute_single_statement('DROP DATABASE {0};'.format(cls.database)))
+            list(client.execute_single_statement('DROP INDEX {0} ON {1};'.format(cls.index, cls.table2)))
+            list(client.execute_single_statement('DROP TABLE {0};'.format(cls.table1)))
+            list(client.execute_single_statement('DROP TABLE {0};'.format(cls.table2)))
+            list(client.execute_single_statement('DROP VIEW {0};'.format(cls.view)))
+            list(client.execute_single_statement('DROP SCHEMA {0};'.format(cls.schema)))
+            list(client.execute_single_statement('DROP FUNCTION {0}'.format(cls.function)))
+            list(client.execute_single_statement('DROP LOGIN {0}'.format(cls.login)))
         finally:
             shutdown(client)
 
@@ -81,7 +81,7 @@ class SpecialCommandsTests(unittest.TestCase):
         try:
             client = create_mssql_cli_client()
             for rows, col, message, query, is_error in \
-                client.execute_multi_statement_single_batch('\\sf {0}'.format(self.function)):
+                client.execute_multi_statement('\\sf {0}'.format(self.function)):
                     self.assertTrue(len(rows) == 1)
                     self.assertTrue(len(col) == 1)
         finally:
@@ -92,7 +92,7 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
             result_set_count = 0
             for rows, col, message, query, is_error in \
-                client.execute_multi_statement_single_batch('\\d {0}'.format(self.function)):
+                client.execute_multi_statement('\\d {0}'.format(self.function)):
                     result_set_count += 1
 
             self.assertTrue(result_set_count == 2)
@@ -104,28 +104,28 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
 
             # Save named queries
-            list(client.execute_multi_statement_single_batch('\\sn test123 select 1'))
-            list(client.execute_multi_statement_single_batch('\\sn test234 select 2'))
+            list(client.execute_multi_statement('\\sn test123 select 1'))
+            list(client.execute_multi_statement('\\sn test234 select 2'))
 
             # List named queries
-            for rows, col, message, sql, is_error in client.execute_multi_statement_single_batch('\\n'):
+            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n'):
                 self.assertTrue(len(rows) >= 2)
                 num_queries = len(rows)
 
             # Execute named query created above
-            for rows, col, message, sql, is_error in client.execute_multi_statement_single_batch('\\n test123'):
+            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n test123'):
                 self.assertTrue(len(rows) == 1)
                 self.assertTrue(len(col) == 1)
 
             # Delete a named query that was created
-            list(client.execute_multi_statement_single_batch('\\dn test123'))
+            list(client.execute_multi_statement('\\dn test123'))
 
             # Number of named queries should have reduced by 1
-            for rows, col, message, sql, is_error in client.execute_multi_statement_single_batch('\\n'):
+            for rows, col, message, sql, is_error in client.execute_multi_statement('\\n'):
                 self.assertTrue(num_queries-1 == len(rows))
 
             # Clean up the second named query created
-            list(client.execute_multi_statement_single_batch('\\dn test234'))
+            list(client.execute_multi_statement('\\dn test234'))
 
         finally:
             shutdown(client)
@@ -144,14 +144,14 @@ class SpecialCommandsTests(unittest.TestCase):
             client = create_mssql_cli_client()
 
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement_single_batch(command):
+                    client.execute_multi_statement(command):
                 self.assertTrue(len(rows) >= min_rows_expected)
                 self.assertTrue(len(col) == cols_expected)
 
             # execute with pattern and verbose
             command = command + "+ " + pattern
             for rows, col, message, query, is_error in \
-                    client.execute_multi_statement_single_batch(command):
+                    client.execute_multi_statement(command):
                 self.assertTrue(len(rows) == rows_expected_pattern_query)
                 self.assertTrue(len(col) == cols_expected_verbose)
         finally:


### PR DESCRIPTION
Changes made:

**Argument handling**
- Moved from click to argparse. Still retaining click for it's echo via pager API.
- All objects are accessed via the namespace object generated by argparser.
- Arg parse can handle defaults better, no longer requiring explicit checks to set another option. 
   Example: If no server is passed in, we automatically target master. This reduced checks and centralizes all options into a single file.

**Tests**
- Tests have been updated to handle options via a namespace object. This allows each test method to express what options to toggle along with retaining default values. 
 - All mssql client and option creations are centralized and no longer need explicitly set values on all calls unless a non default option is necessary. This is evident in test_mssqlcliclient.py and test_rowlimit.py

**Miscellaneous**
- Methods were renamed for readability.
- Added additional layers of abstraction for readability.
- Messages logged are trimmed since some did not provide additional value.
- Updated mssqlcliclient to support a shallow clone method.
- Mssqlcliclient has private methods added to abstract away the connection and query execution API.
- sqltoolsclient API are expressed in a class variable so as to avoid any hardcoded JSON RPC calls.
- lower case all action for build.py for robustness.