### PR TITLE
Updating dev setup to not install from cache dir.

### DIFF
--- a/dev_setup.py
+++ b/dev_setup.py
@@ -6,7 +6,7 @@ print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(utility.ROOT_DIR))
 
 # install general requirements.
-utility.exec_command('pip install -r requirements-dev.txt', utility.ROOT_DIR)
+utility.exec_command('pip install --no-cache-dir -r requirements-dev.txt', utility.ROOT_DIR)
 
 # install mssqltoolsservice if this platform supports it.
 utility.copy_current_platform_mssqltoolsservice()


### PR DESCRIPTION
Our builds have been using cached dependencies, which lead to a python 2.7 failure for validating packages on linux. 

In particular when we are validating a package, we assume the dependencies of that package are installed from a previous step. The caveat is that the dependencies had to have been installed not from a cache. This was not the case for argparse.

Updating dev_setup.py to install dependencies not from cache, which will ensure we always have fresh dependencies and not rely on a build machine containing dependencies from a previous run.