### PR TITLE
Adding overrides to debian script file.

### DIFF
--- a/build_scripts/debian/dir_creator.sh
+++ b/build_scripts/debian/dir_creator.sh
@@ -88,7 +88,7 @@ ${TAB}cp -a python_env/* debian/mssql-cli/mssql-cli
 ${TAB}mkdir -p debian/mssql-cli/usr/bin/
 ${TAB}echo "if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi" > debian/mssql-cli/usr/bin/mssql-cli
 ${TAB}echo "\043!/usr/bin/env bash\n/mssql-cli/bin/python3 -Im mssqlcli.main \"\044\100\"" > debian/mssql-cli/usr/bin/mssql-cli
-${TAB}chmod 0755 debian/mssql-cli/usr/bin/mssql-clip
+${TAB}chmod 0755 debian/mssql-cli/usr/bin/mssql-cli
 
 override_dh_strip:
 ${TAB}dh_strip --exclude=_cffi_backend

--- a/build_scripts/debian/dir_creator.sh
+++ b/build_scripts/debian/dir_creator.sh
@@ -80,13 +80,15 @@ cat > $debian_dir/rules << EOM
 %:
 ${TAB}dh \$@ --sourcedirectory $source_dir
 
+override_dh_auto_build:
+override_dh_auto_install:
 override_dh_install:
 ${TAB}mkdir -p debian/mssql-cli/mssql-cli
 ${TAB}cp -a python_env/* debian/mssql-cli/mssql-cli
 ${TAB}mkdir -p debian/mssql-cli/usr/bin/
 ${TAB}echo "if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi" > debian/mssql-cli/usr/bin/mssql-cli
 ${TAB}echo "\043!/usr/bin/env bash\n/mssql-cli/bin/python3 -Im mssqlcli.main \"\044\100\"" > debian/mssql-cli/usr/bin/mssql-cli
-${TAB}chmod 0755 debian/mssql-cli/usr/bin/mssql-cli
+${TAB}chmod 0755 debian/mssql-cli/usr/bin/mssql-clip
 
 override_dh_strip:
 ${TAB}dh_strip --exclude=_cffi_backend


### PR DESCRIPTION
Current package build will bundle in python 2.7.
This is because Debian is super smart and when it detects a setup.py file it will build it and bundle it into the package. To prevent this we will override the steps that would attempt to build the python package to do nothing since we are not purely a python package from the debian perspective.