### PR TITLE
Ron/package rename step

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,5 +9,3 @@ serialize =
 [bumpversion:file:build_scripts/debian/build.sh]
 
 [bumpversion:file:build_scripts/rpm/mssql-cli.spec]
-
-[bumpversion:file:build_scripts/rpm/build.sh]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,3 +9,5 @@ serialize =
 [bumpversion:file:build_scripts/debian/build.sh]
 
 [bumpversion:file:build_scripts/rpm/mssql-cli.spec]
+
+[bumpversion:file:build_scripts/rpm/build.sh]

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -80,5 +80,5 @@ cd $source_dir
 dpkg-buildpackage -us -uc
 cp $deb_file $source_dir/../debian_output
 # Create a second copy for latest dev version to be used by homepage.
-cp $deb_file $source_dir/../debian_output/mssql-cli-Latest.deb
+cp $deb_file $source_dir/../debian_output/mssql-cli-latest.deb
 echo "The archive has also been outputted to $source_dir/../debian_output"

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -80,5 +80,5 @@ cd $source_dir
 dpkg-buildpackage -us -uc
 cp $deb_file $source_dir/../debian_output
 # Create a second copy for latest dev version to be used by homepage.
-cp $deb_file $source_dir/../debian_output/mssql-cli_$CLI_VERSION-Latest.deb
+cp $deb_file $source_dir/../debian_output/mssql-cli-Latest.deb
 echo "The archive has also been outputted to $source_dir/../debian_output"

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -79,4 +79,6 @@ cp -r $cli_debian_dir_tmp/* $source_dir/debian
 cd $source_dir
 dpkg-buildpackage -us -uc
 cp $deb_file $source_dir/../debian_output
+# Create a second copy for latest dev version to be used by homepage.
+cp $deb_file $source_dir/../debian_output/mssql-cli_$CLI_VERSION-Latest.deb
 echo "The archive has also been outputted to $source_dir/../debian_output"

--- a/build_scripts/rpm/build.sh
+++ b/build_scripts/rpm/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CLI_VERSION=0.10.0
+
 if [ -z "$1" ]
   then
     echo "Argument should be path to local repo."
@@ -17,4 +19,6 @@ rpmbuild -v -bb --clean mssql-cli.spec
 # Copy build artifact to output dir.
 mkdir ${REPO_PATH}/../rpm_output
 cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output
+# Create a second copy for latest dev version to be used by homepage.
+cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli_$CLI_VERSION-Latest.rpm
 echo "The archive has also been outputted to ${REPO_PATH}/../rpm_output"

--- a/build_scripts/rpm/build.sh
+++ b/build_scripts/rpm/build.sh
@@ -18,5 +18,5 @@ rpmbuild -v -bb --clean mssql-cli.spec
 mkdir ${REPO_PATH}/../rpm_output
 cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output
 # Create a second copy for latest dev version to be used by homepage.
-cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli-Latest.rpm
+cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli-latest.rpm
 echo "The archive has also been outputted to ${REPO_PATH}/../rpm_output"

--- a/build_scripts/rpm/build.sh
+++ b/build_scripts/rpm/build.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-CLI_VERSION=0.10.0
-
 if [ -z "$1" ]
   then
     echo "Argument should be path to local repo."
@@ -20,5 +18,5 @@ rpmbuild -v -bb --clean mssql-cli.spec
 mkdir ${REPO_PATH}/../rpm_output
 cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output
 # Create a second copy for latest dev version to be used by homepage.
-cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli_$CLI_VERSION-Latest.rpm
+cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli-Latest.rpm
 echo "The archive has also been outputted to ${REPO_PATH}/../rpm_output"


### PR DESCRIPTION
Adding a additional step when copying the deb and rpm package to the output dir to copy additional package renamed to mssql-cli-latest.deb and mssql-cli-latest.rpm.

All daily builds will update this package in the storage account so users can always access the latest package with a single URL.

Readme's will be updated once we have the whl container set up for mssql-cli wheels.