### PR TITLE
Telemetry updates

### DIFF
--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -20,7 +20,6 @@ try:
 except ImportError:
     from urllib.parse import urlparse, unquote, parse_qs
 
-from mssqlcli.mssql_cli import MssqlCli
 from mssqlcli.mssqlclioptionsparser import create_parser
 import mssqlcli.telemetry as telemetry_session
 
@@ -46,6 +45,10 @@ def run_cli_with(options):
     display_integrated_auth_message_for_non_windows(options)
 
     configure_and_update_options(options)
+
+    # Importing MssqlCli creates a config dir by default.
+    # Moved import here so we can create the config dir for first use prior.
+    from mssqlcli.mssql_cli import MssqlCli
 
     mssqlcli = MssqlCli(options)
     mssqlcli.connect_to_database()

--- a/mssqlcli/telemetry.py
+++ b/mssqlcli/telemetry.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 import uuid
 from functools import wraps
-from datetime import datetime as temp
+from datetime import datetime as datetime_2
 from datetime import timedelta
 import datetime
 import mssqlcli.config as config
@@ -186,22 +186,20 @@ def _get_user_id():
 
 def _user_id_file_is_old(id_file_path):
     if os.path.exists(id_file_path):
-        last_24_hours = temp.now() - timedelta(hours=24)
-        id_file_creation_time = temp.fromtimestamp(os.path.getctime(id_file_path))
+        last_24_hours = datetime_2.now() - timedelta(hours=24)
+        id_file_modified_time = datetime_2.fromtimestamp(os.path.getmtime(id_file_path))
 
-        return id_file_creation_time < last_24_hours
+        return id_file_modified_time < last_24_hours
     return False
 
 
 @decorators.suppress_all_exceptions(fallback_return='')
 @decorators.hash256_result
 def _generate_user_id():
-    random_id = binascii.hexlify(os.urandom(16)).decode() \
-        if sys.version_info >= (3,0) else binascii.hexlify(os.urandom(16))
-    salt = binascii.hexlify(os.urandom(16)).decode() \
-        if sys.version_info >= (3,0) else binascii.hexlify(os.urandom(16))
+    random_id = binascii.hexlify(os.urandom(32)).decode() \
+        if sys.version_info >= (3,0) else binascii.hexlify(os.urandom(32))
 
-    return random_id + salt
+    return random_id
 
 
 def _get_env_string():

--- a/mssqlcli/telemetry.py
+++ b/mssqlcli/telemetry.py
@@ -196,8 +196,10 @@ def _user_id_file_is_old(id_file_path):
 @decorators.suppress_all_exceptions(fallback_return='')
 @decorators.hash256_result
 def _generate_user_id():
-    random_id = os.urandom(16)
-    salt = os.urandom(16)
+    random_id = binascii.hexlify(os.urandom(16)).decode() \
+        if sys.version_info >= (3,0) else binascii.hexlify(os.urandom(16))
+    salt = binascii.hexlify(os.urandom(16)).decode() \
+        if sys.version_info >= (3,0) else binascii.hexlify(os.urandom(16))
 
     return random_id + salt
 

--- a/mssqlcli/telemetry_upload.py
+++ b/mssqlcli/telemetry_upload.py
@@ -121,10 +121,6 @@ def build_vortex_telemetry_client(service_endpoint_uri):
 
     client = TelemetryClient(INSTRUMENTATION_KEY, channel)
 
-    # Prevent appinsights from reporting these data points.
-    client.context.device.ip = ""
-    client.context.device.role_instance = ""
-
     enable(INSTRUMENTATION_KEY)
     return client
 

--- a/mssqlcli/telemetry_upload.py
+++ b/mssqlcli/telemetry_upload.py
@@ -1,9 +1,10 @@
+import datetime
 import json
 import os
 import sys
 
 from applicationinsights import TelemetryClient
-from applicationinsights.channel import TelemetryChannel, SynchronousQueue, SynchronousSender
+from applicationinsights.channel import TelemetryChannel, SynchronousQueue, SynchronousSender, contracts
 from applicationinsights.exceptions import enable
 
 import mssqlcli.decorators as decorators
@@ -39,7 +40,7 @@ class VortexSynchronousSender(SynchronousSender):
 
     def send(self, data_to_send):
         """
-            Override the send method to strip the request_payload's brackets since Vortex does not
+            Override the send method to strip the request_payload's brackets since Vortex does not.
         """
         request_payload = json.dumps([a.write() for a in data_to_send]).strip('[').strip(']')
 
@@ -67,15 +68,63 @@ class VortexSynchronousSender(SynchronousSender):
             self._queue.put(data)
 
 
+class VortexTelemetryChannel(TelemetryChannel):
+    """
+        A Vortext telemetry channel that suppresses the ingest header.
+    """
+    def __init__(self, context=None, queue=None):
+        TelemetryChannel.__init__(self, context, queue)
+
+    def write(self, data, context=None):
+        """
+            Enqueues the passed in data to the queue.
+        """
+        local_context = context or self._context
+        if not local_context:
+            raise Exception('Context was required but not provided')
+
+        if not data:
+            raise Exception('Data was required but not provided')
+
+        envelope = contracts.Envelope()
+        # The only difference in behavior from it's parent class is setting the flag below.
+        # Suppress Vortex ingest header.
+        envelope.flags = 0x200000
+        envelope.name = data.ENVELOPE_TYPE_NAME
+        envelope.time = datetime.datetime.utcnow().isoformat() + 'Z'
+        envelope.ikey = local_context.instrumentation_key
+        tags = envelope.tags
+        for key, value in self._write_tags(local_context):
+            tags[key] = value
+        envelope.data = contracts.Data()
+        envelope.data.base_type = data.DATA_TYPE_NAME
+        if hasattr(data, 'properties') and local_context.properties:
+            properties = data.properties
+            if not properties:
+                properties = {}
+                data.properties = properties
+            for key in local_context.properties:
+                if key not in properties:
+                    properties[key] = local_context.properties[key]
+        envelope.data.base_data = data
+
+        self._queue.put(envelope)
+
+
 def build_vortex_telemetry_client(service_endpoint_uri):
     """
         Build vortex telemetry client.
     """
     vortex_sender = VortexSynchronousSender(service_endpoint_uri)
     sync_queue = SynchronousQueue(vortex_sender)
-    channel = TelemetryChannel(None, queue=sync_queue)
+    channel = VortexTelemetryChannel(None, queue=sync_queue)
 
     client = TelemetryClient(INSTRUMENTATION_KEY, channel)
+
+    # Prevent appinsights from reporting these data points.
+    client.context.device.ip = ""
+    client.context.device.role_instance = ""
+
     enable(INSTRUMENTATION_KEY)
     return client
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,10 +3,11 @@ import tempfile
 import json
 import os
 import unittest
+from stat import ST_MTIME
 
 import mssqlcli.telemetry_upload as telemetry_upload
 
-from stat import ST_MTIME
+
 try:
     # Python 2.x
     import urllib2 as HTTPClient

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -113,6 +113,8 @@ class TelemetryTests(unittest.TestCase):
             self.assertFalse(test_telemetry_client._user_id_file_is_old(valid_id_file.name))
         finally:
             expired_id_file.close()
+            valid_id_file.close()
+
 
 if __name__ == u'__main__':
     # Enabling this env var would output what telemetry payload is sent.


### PR DESCRIPTION
- Daily user id rotation: We generate a new cryptographically secure id for the user for each 24 hour window of usage.

- Moved import statement to prevent creation of config dir prior to check so we can display telemetry message.

- Added envelope flag to suppress ingest header for vortex.