### PR TITLE
Removing blocker when using integrated auth on Mac/Linux 

### DIFF
--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -42,7 +42,6 @@ def run_cli_with(options):
         display_telemetry_message()
 
     display_version_message(options)
-    display_integrated_auth_message_for_non_windows(options)
 
     configure_and_update_options(options)
 
@@ -75,12 +74,6 @@ def create_config_dir_for_first_use():
         return True
 
     return False
-
-
-def display_integrated_auth_message_for_non_windows(options):
-    if platform.system().lower() != 'windows' and options.integrated_auth:
-        options.integrated_auth = False
-        print(u'Integrated authentication not supported on this platform')
 
 
 def display_version_message(options):

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -47,7 +47,7 @@ def create_parser():
         help=u'SQL Server instance name or address.')
 
     args_parser.add_argument(
-        u'-I', u'--integrated',
+        u'-E', u'--integrated',
         dest=u'integrated_auth',
         action=u'store_true',
         default=False,


### PR DESCRIPTION
- Also renaming parameter for integrated auth from -I to -E to align with SqlCMD and what it was originally.