### PR TITLE
Updating exception test for json rpc to only validate exception message.

### DIFF
--- a/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
+++ b/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
@@ -206,10 +206,7 @@ class JsonRpcClientTests(unittest.TestCase):
             self.assertEqual(
                 str(exception), u'I/O operation on closed file.')
 
-            self.assertTrue(test_client.request_thread.isAlive())
-            self.assertFalse(test_client.response_thread.isAlive())
             test_client.shutdown()
-            self.assertFalse(test_client.request_thread.isAlive())
 
     @unittest.skip("Disabling until scenario is valid")
     def test_stream_has_no_response(self):


### PR DESCRIPTION
Thread behavior can be inconsistent on different platforms, so removing the thread alive checks since we only care about the exception message for that test.