### PR TITLE
Update usage_guide.md

### DIFF
--- a/doc/usage_guide.md
+++ b/doc/usage_guide.md
@@ -30,7 +30,7 @@ Options:
     -S, --server TEXT       SQL Server instance name or address.
     -U, --username TEXT     Username to connect to the database.
     -W, --password          Force password prompt.
-    -I, --integrated        Use integrated authentication on windows.
+    -E, --integrated        Use integrated authentication on windows.
     -v, --version           Version of mssql-cli.
     -d, --database TEXT     database name to connect to.
     --mssqlclirc TEXT       Location of mssqlclirc config file.


### PR DESCRIPTION
Instructions say -I for Windows Authentication. It should be -E.
Updated -I to -E.