### PR TITLE
moved to use python3, fixed install docs.

### DIFF
--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -2,9 +2,7 @@
 
 Supports:
 
-- [Ubuntu 14.04][u14]
-- [Ubuntu 16.04][u16]
-- [Ubuntu 17.04][u17]
+- [Ubuntu][u]
 - [Debian 8][deb8]
 - [Debian 9][deb9]
 - [CentOS 7][cos]
@@ -18,21 +16,19 @@ Supports:
 
 Once the package is installed, run `mssql-cli` from a terminal.
 
-[u14]: #ubuntu-1404
-[u16]: #ubuntu-1604
-[u17]: #ubuntu-1704
-[deb8]: #debian-8
-[deb9]: #debian-9
-[cos]: #centos-7
-[rhel7]: #red-hat-enterprise-linux-rhel-7
+[u]:        #ubuntu
+[deb8]:     #debian-8
+[deb9]:     #debian-9
+[cos]:      #centos-7
+[rhel7]:    #red-hat-enterprise-linux-rhel-7
 [opensuse]: #opensuse-422
-[sles12]: #sles-12
-[fed25]: #fedora-25
-[fed26]: #fedora-26
+[sles12]:   #sles-12
+[fed25]:    #fedora-25
+[fed26]:    #fedora-26
 
-## Ubuntu 14.04
+## Ubuntu
 
-### Installation for latest stable version via Package Repository - Ubuntu 14.04
+### Installation for latest stable version via Package Repository
 
 mssql-cli, for Linux, is published to package repositories for easy installation (and updates).
 This is the preferred method.
@@ -42,7 +38,7 @@ This is the preferred method.
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
 # Register the Microsoft Ubuntu repository
-sudo curl -o /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/14.04/prod.list
+sudo curl -o /etc/apt/sources.list.d/microsoft.list "https://packages.microsoft.com/config/ubuntu/$(lsb_release -sr)/prod.list"
 
 # Update the list of products
 sudo apt-get update
@@ -57,10 +53,9 @@ mssql-cli
 After registering the Microsoft repository once as superuser,
 from then on, you just need to use `sudo apt-get upgrade mssql-cli` to update it.
 
-### Installation for latest preview version via Direct Download - Ubuntu 14.04
+### Installation for latest preview version via Direct Download
 
-Download the Debian package
-`mssql-cli-dev-latest.deb`
+Download the Debian package `mssql-cli-dev-latest.deb`
 from the [downloads] page onto the Ubuntu machine.
 
 Then execute the following in the terminal:
@@ -74,106 +69,7 @@ sudo apt-get install -f
 > the next command, `apt-get install -f` resolves these
 > and then finishes configuring the mssql-cli package.
 
-### Uninstallation - Ubuntu 14.04
-
-```sh
-sudo apt-get remove mssql-cli
-```
-
-## Ubuntu 16.04
-
-### Installation for latest stable version via Package Repository - Ubuntu 16.04
-
-mssql-cli, for Linux, is published to package repositories for easy installation (and updates).
-This is the preferred method.
-
-```sh
-# Import the public repository GPG keys
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-
-# Register the Microsoft Ubuntu repository
-sudo curl -o /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/16.04/prod.list
-
-# Update the list of products
-sudo apt-get update
-
-# Install mssql-cli
-sudo apt-get install mssql-cli
-
-# Start mssql-cli
-mssql-cli
-```
-
-After registering the Microsoft repository once as superuser,
-from then on, you just need to use `sudo apt-get upgrade mssql-cli` to update it.
-
-### Installation for latest preview version  via Direct Download - Ubuntu 16.04
-
-Download the Debian package
-`mssql-cli-dev-latest.deb`
-from the [downloads] page onto the Ubuntu machine.
-
-Then execute the following in the terminal:
-
-```sh
-sudo dpkg -i mssql-cli-dev-latest.deb
-sudo apt-get install -f
-```
-
-> Please note that `dpkg -i` will fail with unmet dependencies;
-> the next command, `apt-get install -f` resolves these
-> and then finishes configuring the mssql-cli package.
-
-### Uninstallation - Ubuntu 16.04
-
-```sh
-sudo apt-get remove mssql-cli
-```
-
-## Ubuntu 17.04
-
-### Installation for latest stable version via Package Repository - Ubuntu 17.04
-mssql-cli, for Linux, is published to package repositories for easy installation (and updates).
-This is the preferred method.
-
-```sh
-# Import the public repository GPG keys
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-
-# Register the Microsoft Ubuntu repository
-sudo curl -o /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/17.04/prod.list
-
-# Update the list of products
-sudo apt-get update
-
-# Install mssql-cli
-sudo apt-get install mssql-cli
-
-# Start mssql-cli
-mssql-cli
-```
-
-After registering the Microsoft repository once as superuser,
-from then on, you just need to use `sudo apt-get upgrade mssql-cli` to update it.
-
-### Installation for latest preview version via Direct Download - Ubuntu 17.04
-
-Download the Debian package
-`mssql-cli-dev-latest.deb`
-from the [downloads] page onto the Ubuntu machine.
-
-Then execute the following in the terminal:
-
-```sh
-sudo dpkg -i mssql-cli-dev-latest.deb
-sudo apt-get install -f
-```
-
-> Please note that `dpkg -i` will fail with unmet dependencies;
-> the next command, `apt-get install -f` resolves these
-> and then finishes configuring the mssql-cli package.
-
-### Uninstallation - Ubuntu 17.04
+### Uninstallation - Ubuntu
 
 ```sh
 sudo apt-get remove mssql-cli

--- a/doc/installation/pip.md
+++ b/doc/installation/pip.md
@@ -40,9 +40,9 @@ For supported operating system specific installations, see one of the following 
     * [Red Hat Enterprise Linux 7](#install-red-hat-enterprise-linux-rhel-7)
     * [CentOS 7](#install-centos-7)
     * [Fedora 25, Fedora 26](#install-fedora-25-fedora-26)
-    * [Debian 8.7 or later versions](#install-debian-87-or-later)
-    * [Ubuntu 17.04, Ubuntu 16.04, Ubuntu 14.04](#install-ubuntu-1704-ubuntu-1604-ubuntu-1404)
-    * [Linux Mint 18, Linux Mint 17](#install-linux-mint-18-linux-mint-17)
+    * [Debian 8.7 or later versions](#install-ubuntu-debian-mint)
+    * [Ubuntu 17.04, Ubuntu 16.04, Ubuntu 14.04](#install-ubuntu-debian-mint)
+    * [Linux Mint 18, Linux Mint 17](#install-ubuntu-debian-mint)
     * [openSUSE 42.2 or later](#install-opensuse-422-or-later)
     * [SUSE Enterprise Linux (SLES) 12 SP2 or later](#install-suse-enterprise-linux-sles-12-sp2-or-later)
 
@@ -93,52 +93,14 @@ $ dnf install libunwind libicu python-pip
 $ sudo pip install mssql-cli
 ```
 
-## Install Debian 8.7 or later
+## Install Ubuntu / Debian / Mint
+
 ```shell
-$ echo deb http://ftp.us.debian.org/debian jessie main | sudo tee -a /etc/apt/sources.list
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
+$ sudo apt-get update & sudo apt-get install -y libunwind8 python3-pip
+$ sudo apt-get install -y libicu60 2> /dev/null || sudo apt-get install -y libicu57 2> /dev/null || sudo apt-get install -y libicu55 2> /dev/null || sudo apt-get install -y libicu55 2> /dev/null || sudo apt-get install -y libicu52
+$ pip3 install --user mssql-cli
 ```
 
-## Install Ubuntu 17.04, Ubuntu 16.04, Ubuntu 14.04
-
-### Install Ubuntu 17.04
-```shell
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip libicu57
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
-```
-
-### Install Ubuntu 16.04
-```shell
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip libicu55 
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
-```
-
-### Install Ubuntu 14.04
-```shell
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip libicu52
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
-```
-
-## Install Linux Mint 18, Linux Mint 17
-
-### Install Linux Mint 18
-```shell
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip libicu57
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
-```
-
-### Install Linux Mint 17
-```shell
-$ sudo apt-get update & sudo apt-get install -y libunwind8 python-pip libicu55
-$ sudo pip install --upgrade pip
-$ sudo pip install mssql-cli
-```
 
 ### Install OpenSUSE 42.2 or later
 ```shell

--- a/mssql-cli
+++ b/mssql-cli
@@ -13,4 +13,4 @@ if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi
 
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 
-python -m mssqlcli.main "$@"
+( command -v python3 && python3 -m mssqlcli.main "$@" ) || python -m mssqlcli.main "$@"


### PR DESCRIPTION
There is no reason to have different install docs for each different Debian-based distro. Now we have one set of docs that should work with them all (include Ubuntu and Mint). Also made pip install dependant on pip3 for Debian based distros. Made the `mssql-cli` check for the existance of python3, before falling back to python. Python is not the "default" for Python2/3. Python3 should be the default.