### PR TITLE
Fixed broken unit tests: test_mssqlcliclient.py and test_completion_refresher.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -122,6 +122,7 @@ def unit_test():
     utility.exec_command(
         'pytest --cov mssqlcli '
         'tests/test_mssqlcliclient.py '
+        'tests/test_completion_refresher.py ',
         'tests/test_main.py '
         'tests/test_fuzzy_completion.py '
         'tests/test_rowlimit.py '

--- a/mssqlcli/completion_refresher.py
+++ b/mssqlcli/completion_refresher.py
@@ -97,10 +97,10 @@ def refresher(name, refreshers=CompletionRefresher.refreshers):
     return wrapper
 
 
-@refresher('schemata')
+@refresher('schemas')
 @decorators.suppress_all_exceptions()
-def refresh_schemata(completer, mssqlcliclient):
-    completer.extend_schemata(mssqlcliclient.get_schemas())
+def refresh_schemas(completer, mssqlcliclient):
+    completer.extend_schemas(mssqlcliclient.get_schemas())
 
 
 @refresher('tables')

--- a/mssqlcli/mssqlqueries.py
+++ b/mssqlcli/mssqlqueries.py
@@ -90,8 +90,7 @@ def get_views():
     return '''
         SELECT  table_schema,
                 table_name
-        FROM INFORMATION_SCHEMA.TABLES
-        WHERE table_type = 'View'
+        FROM INFORMATION_SCHEMA.VIEWS
         ORDER BY 1, 2'''
 
 

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -1,87 +1,82 @@
 import time
-import pytest
+import unittest
 from mock import Mock, patch
+from mssqlcli.completion_refresher import CompletionRefresher
 
+class CompletionRefresherTests(unittest.TestCase):
 
-@pytest.fixture
-def refresher():
-    from mssqlcli.completion_refresher import CompletionRefresher
-    return CompletionRefresher()
+    def test_ctor(self):
+        """
+        Refresher object should contain a few handlers
+        :param refresher:
+        :return:
+        """
+        refresher = CompletionRefresher()
+        assert len(refresher.refreshers) > 0
+        actual_handlers = set(refresher.refreshers.keys())
+        expected_handlers = set(['databases', 'schemata', 'tables', 'types', 'views'])
+        assert expected_handlers == actual_handlers
 
+    def test_refresh_called_once(self):
+        """
 
-def test_ctor(refresher):
-    """
-    Refresher object should contain a few handlers
-    :param refresher:
-    :return:
-    """
-    assert len(refresher.refreshers) > 0
-    actual_handlers = list(refresher.refreshers.keys())
-    expected_handlers = ['schemata', 'tables', 'views',
-                         'types', 'databases', 'casing', 'functions']
-    assert expected_handlers == actual_handlers
+        :param refresher:
+        :return:
+        """
+        callbacks = Mock()
+        mssqlcliclient = Mock()
+        refresher = CompletionRefresher()
 
+        with patch.object(refresher, '_bg_refresh') as bg_refresh:
+            actual = refresher.refresh(mssqlcliclient, callbacks)
+            time.sleep(1)  # Wait for the thread to work.
+            assert len(actual) == 1
+            assert len(actual[0]) == 4
+            assert actual[0][3] == 'Auto-completion refresh started in the background.'
+            bg_refresh.assert_called_with(mssqlcliclient, callbacks, None, None)
 
-def test_refresh_called_once(refresher):
-    """
+    def test_refresh_called_twice(self):
+        """
+        If refresh is called a second time, it should be restarted
+        :param refresher:
+        :return:
+        """
+        callbacks = Mock()
+        mssqlcliclient = Mock()
+        refresher = CompletionRefresher()
 
-    :param refresher:
-    :return:
-    """
-    callbacks = Mock()
-    pgexecute = Mock()
+        def bg_refresh_mock(*args):
+            time.sleep(3)  # seconds
 
-    with patch.object(refresher, '_bg_refresh') as bg_refresh:
-        actual = refresher.refresh(pgexecute, callbacks)
+        refresher._bg_refresh = bg_refresh_mock
+
+        actual1 = refresher.refresh(mssqlcliclient, callbacks)
         time.sleep(1)  # Wait for the thread to work.
-        assert len(actual) == 1
-        assert len(actual[0]) == 4
-        assert actual[0][3] == 'Auto-completion refresh started in the background.'
-        bg_refresh.assert_called_with(pgexecute, callbacks, None,
-            None)
+        assert len(actual1) == 1
+        assert len(actual1[0]) == 4
+        assert actual1[0][3] == 'Auto-completion refresh started in the background.'
 
+        actual2 = refresher.refresh(mssqlcliclient, callbacks)
+        time.sleep(1)  # Wait for the thread to work.
+        assert len(actual2) == 1
+        assert len(actual2[0]) == 4
+        assert actual2[0][3] == 'Auto-completion refresh restarted.'
 
-def test_refresh_called_twice(refresher):
-    """
-    If refresh is called a second time, it should be restarted
-    :param refresher:
-    :return:
-    """
-    callbacks = Mock()
-
-    pgexecute = Mock()
-
-    def dummy_bg_refresh(*args):
-        time.sleep(3)  # seconds
-
-    refresher._bg_refresh = dummy_bg_refresh
-
-    actual1 = refresher.refresh(pgexecute, callbacks)
-    time.sleep(1)  # Wait for the thread to work.
-    assert len(actual1) == 1
-    assert len(actual1[0]) == 4
-    assert actual1[0][3] == 'Auto-completion refresh started in the background.'
-
-    actual2 = refresher.refresh(pgexecute, callbacks)
-    time.sleep(1)  # Wait for the thread to work.
-    assert len(actual2) == 1
-    assert len(actual2[0]) == 4
-    assert actual2[0][3] == 'Auto-completion refresh restarted.'
-
-
-def test_refresh_with_callbacks(refresher):
-    """
-    Callbacks must be called
-    :param refresher:
-    """
-    callbacks = [Mock()]
-    pgexecute_class = Mock()
-    pgexecute = Mock()
-    pgexecute.extra_args = {}
-
-    with patch('pgcli.completion_refresher.PGExecute', pgexecute_class):
+    def test_refresh_with_callbacks(self):
+        """
+        Callbacks must be called
+        :param refresher:
+        """
+        class MssqlCliClientMock:
+            def connect_to_database(self):
+                return 'connectionservicetest', []
+        
+        mssqlcliclient = MssqlCliClientMock()
+        callbacks = [Mock()]
+        refresher = CompletionRefresher()
+        
         # Set refreshers to 0: we're not testing refresh logic here
         refresher.refreshers = {}
-        refresher.refresh(pgexecute, callbacks)
+        refresher.refresh(mssqlcliclient, callbacks)
         time.sleep(1)  # Wait for the thread to work.
         assert (callbacks[0].call_count == 1)

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -14,7 +14,7 @@ class CompletionRefresherTests(unittest.TestCase):
         refresher = CompletionRefresher()
         assert len(refresher.refreshers) > 0
         actual_handlers = set(refresher.refreshers.keys())
-        expected_handlers = set(['databases', 'schemata', 'tables', 'types', 'views'])
+        expected_handlers = set(['databases', 'schemas', 'tables', 'types', 'views'])
         assert expected_handlers == actual_handlers
 
     def test_refresh_called_once(self):
@@ -74,7 +74,7 @@ class CompletionRefresherTests(unittest.TestCase):
         mssqlcliclient = MssqlCliClientMock()
         callbacks = [Mock()]
         refresher = CompletionRefresher()
-        
+
         # Set refreshers to 0: we're not testing refresh logic here
         refresher.refreshers = {}
         refresher.refresh(mssqlcliclient, callbacks)


### PR DESCRIPTION
Fixed broken unit tests (`test_mssqlcliclient.py` and `test_completion_refresher.py`)

Failed unit tests in `test_mssqlcliclient.py`
* test_schema_table_views_and_columns_query
  * Cause: `client.get_views()` failed to retrieve list of views since it uses query with where clause `WHERE table_type = 'View'` that returns nothing on case-sensitive database
  * Fix: Remove the where clause and look up `INFORMATION_SCHEMA.VIEWS` instead of `INFORMATION_SCHEMA.TABLES`

Failed unit tests in `test_completion_refresher.py`

* test_ctor
  * Causes:
    * `refresher.refreshers.keys()` returns only 5 refresher names defined in `completion_refresher.py`
    * `set` comparison should have been used instead of `list` comparison to verify if all elements of `A` are in `B` and all elements of `B` are in `A`
  * Fix
    * Update the `expected_handlers` with appropriate refreshers
    * Use `set` comparison instead of `list`

* test_refresh_with_callbacks
  * Cause: it used wrong mock object for `mssqlcliclient` which blows up when `mssqlcliclient.connect_to_database()` is called.
  * Fix: Create and use mock object for `mssqlcliclient` with `connect_to_database()` implementation.

Changed use unit test framework `unittest` since class type unit test that extends unittest.TestCase (such as test_mssqlcliclient.py) are a lot more convenient to run and manage. 