### PR TITLE
Fixed broken unit test 'test_main.py' and changed `test_fuzzy_completion.py` to use unittest framework

### DIFF
--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -1,3 +1,4 @@
+import os
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
 
@@ -61,3 +62,11 @@ def create_mssql_cli_options(**nondefault_options):
 
 def shutdown(connection):
     connection.shutdown()
+
+def getTempDir(*args):
+    tempDir = os.path.join(os.path.abspath(__file__), '..')
+    for arg in args:
+        tempDir = os.path.join(tempDir, arg)
+    return  os.path.abspath(tempDir)
+
+

--- a/tests/test_fuzzy_completion.py
+++ b/tests/test_fuzzy_completion.py
@@ -1,88 +1,83 @@
 from __future__ import unicode_literals
 import pytest
+import unittest
+import mssqlcli.mssqlcompleter as mssqlcompleter
 
+class FuzzyCompletionTests(unittest.TestCase):
 
-@pytest.fixture
-def completer():
-    import mssqlcli.mssqlcompleter as mssqlcompleter
-    return mssqlcompleter.MssqlCompleter()
+    def getCompleter(self):
+        return mssqlcompleter.MssqlCompleter()
 
+    def test_ranking_ignores_identifier_quotes(self):
+        """When calculating result rank, identifier quotes should be ignored.
 
-def test_ranking_ignores_identifier_quotes(completer):
-    """When calculating result rank, identifier quotes should be ignored.
+        The result ranking algorithm ignores identifier quotes. Without this
+        correction, the match "user", which Postgres requires to be quoted
+        since it is also a reserved word, would incorrectly fall below the
+        match user_action because the literal quotation marks in "user"
+        alter the position of the match.
 
-    The result ranking algorithm ignores identifier quotes. Without this
-    correction, the match "user", which Postgres requires to be quoted
-    since it is also a reserved word, would incorrectly fall below the
-    match user_action because the literal quotation marks in "user"
-    alter the position of the match.
+        This test checks that the fuzzy ranking algorithm correctly ignores
+        quotation marks when computing match ranks.
 
-    This test checks that the fuzzy ranking algorithm correctly ignores
-    quotation marks when computing match ranks.
+        """
+        completer = self.getCompleter()
+        text = 'user'
+        collection = ['user_action', '"user"']
+        matches = completer.find_matches(text, collection)
+        assert len(matches) == 2
 
-    """
+    def test_ranking_based_on_shortest_match(self):
+        """Fuzzy result rank should be based on shortest match.
 
-    text = 'user'
-    collection = ['user_action', '"user"']
-    matches = completer.find_matches(text, collection)
-    assert len(matches) == 2
+        Result ranking in fuzzy searching is partially based on the length
+        of matches: shorter matches are considered more relevant than
+        longer ones. When searching for the text 'user', the length
+        component of the match 'user_group' could be either 4 ('user') or
+        7 ('user_gr').
 
+        This test checks that the fuzzy ranking algorithm uses the shorter
+        match when calculating result rank.
 
-def test_ranking_based_on_shortest_match(completer):
-    """Fuzzy result rank should be based on shortest match.
+        """
+        completer = self.getCompleter()
+        text = 'user'
+        collection = ['api_user', 'user_group']
+        matches = completer.find_matches(text, collection)
+        assert matches[1].priority > matches[0].priority
 
-    Result ranking in fuzzy searching is partially based on the length
-    of matches: shorter matches are considered more relevant than
-    longer ones. When searching for the text 'user', the length
-    component of the match 'user_group' could be either 4 ('user') or
-    7 ('user_gr').
+    def test_should_break_ties_using_lexical_order(self):
+        """Fuzzy result rank should use lexical order to break ties.
 
-    This test checks that the fuzzy ranking algorithm uses the shorter
-    match when calculating result rank.
+        When fuzzy matching, if multiple matches have the same match length and
+        start position, present them in lexical (rather than arbitrary) order. For
+        example, if we have tables 'user', 'user_action', and 'user_group', a
+        search for the text 'user' should present these tables in this order.
 
-    """
+        The input collections to this test are out of order; each run checks that
+        the search text 'user' results in the input tables being reordered
+        lexically.
 
-    text = 'user'
-    collection = ['api_user', 'user_group']
-    matches = completer.find_matches(text, collection)
+        """
+        collections = [
+            ['user_action', 'user'],
+            ['user_group', 'user'],
+            ['user_group', 'user_action'],
+        ]
+        completer = self.getCompleter()
+        text = 'user'
+        for collection in collections:
+            matches = completer.find_matches(text, collection)
+            assert matches[1].priority > matches[0].priority
 
-    assert matches[1].priority > matches[0].priority
+    def test_matching_should_be_case_insensitive(self):
+        """Fuzzy matching should keep matches even if letter casing doesn't match.
 
-
-@pytest.mark.parametrize('collection', [
-    ['user_action', 'user'],
-    ['user_group', 'user'],
-    ['user_group', 'user_action'],
-])
-def test_should_break_ties_using_lexical_order(completer, collection):
-    """Fuzzy result rank should use lexical order to break ties.
-
-    When fuzzy matching, if multiple matches have the same match length and
-    start position, present them in lexical (rather than arbitrary) order. For
-    example, if we have tables 'user', 'user_action', and 'user_group', a
-    search for the text 'user' should present these tables in this order.
-
-    The input collections to this test are out of order; each run checks that
-    the search text 'user' results in the input tables being reordered
-    lexically.
-
-    """
-
-    text = 'user'
-    matches = completer.find_matches(text, collection)
-
-    assert matches[1].priority > matches[0].priority
-
-
-def test_matching_should_be_case_insensitive(completer):
-    """Fuzzy matching should keep matches even if letter casing doesn't match.
-
-    This test checks that variations of the text which have different casing
-    are still matched.
-    """
-
-    text = 'foo'
-    collection = ['Foo', 'FOO', 'fOO']
-    matches = completer.find_matches(text, collection)
-
-    assert len(matches) == 3
+        This test checks that variations of the text which have different casing
+        are still matched.
+        """
+        completer = self.getCompleter()
+        text = 'foo'
+        collection = ['Foo', 'FOO', 'fOO']
+        matches = completer.find_matches(text, collection)
+        assert len(matches) == 3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,168 +1,168 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
 import os
+import unittest
 import tempfile
-
 from time import sleep
-
 from mssqltestutils import (
     create_mssql_cli,
     create_mssql_cli_options,
     create_mssql_cli_client,
-    shutdown
+    shutdown,
+    getTempDir
 )
 from mssqlcli.mssql_cli import OutputSettings, MssqlFileHistory
 
-
-def test_history_file_not_store_credentials():
-    # Used by prompt tool kit, verify statements that contain password or secret
-    # are not stored by the history file.
-    statements = [
-        'Create Database Scoped Credential With Password = <secret>',
-        'CREATE MASTER KEY WITH SECRET=xyz',
-    ]
-
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file_path = temp_file.name
-        file_history = MssqlFileHistory(temp_file_path)
-
-        for statement in statements:
-            file_history.append(statement)
-
-    assert len(file_history) == 0
-
-
-def test_format_output():
-    mssqlcli = create_mssql_cli()
-    settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g')
-    results = mssqlcli.format_output('Title',
-                                     [('abc', 'def')],
-                                     ['head1', 'head2'],
-                                     'test status',
-                                     settings)
-    expected = [
-        'Title',
-        '+---------+---------+',
-        '| head1   | head2   |',
-        '|---------+---------|',
-        '| abc     | def     |',
-        '+---------+---------+',
-        'test status'
-    ]
-    assert list(results) == expected
-
-
-def test_format_output_live_connection():
-    sleep(7)
-    statement = u"""
-        select 1 as [ShiftID], 'Day' as [Name] UNION ALL
-        select 2, N'魚' UNION ALL
-        select 3, 'Night'
-    """
-    try:
-        mssqlcli = create_mssql_cli()
-        result = run_and_return_string_from_formatter(mssqlcli, statement)
-        expected = [
-            u'+-----------+--------+',
-            u'| ShiftID   | Name   |',
-            u'|-----------+--------|',
-            u'| 1         | Day    |',
-            u'| 2         | 魚     |',
-            u'| 3         | Night  |',
-            u'+-----------+--------+',
-            u'(3 rows affected)'
+class MainTests(unittest.TestCase):
+    
+    def test_history_file_not_store_credentials(self):
+        # Used by prompt tool kit, verify statements that contain password or secret
+        # are not stored by the history file.
+        statements = [
+            'Create Database Scoped Credential With Password = <secret>',
+            'CREATE MASTER KEY WITH SECRET=xyz',
         ]
-        assert list(result) == expected
-    finally:
-        shutdown(mssqlcli.mssqlcliclient_main)
 
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = temp_file.name
+            file_history = MssqlFileHistory(temp_file_path)
 
-def test_format_output_expanded_live_connection():
-    statement = u"""
-        select N'配列' as [Name] UNION ALL
-        select 'Evening' UNION ALL
-        select 'Night'
-    """
+            for statement in statements:
+                file_history.append_string(statement)
 
-    try:
+        assert len(file_history.get_strings()) == 0
+
+    def test_format_output(self):
         mssqlcli = create_mssql_cli()
-        result = run_and_return_string_from_formatter(mssqlcli, statement, expanded=True)
-
+        settings = OutputSettings(table_format='psql', dcmlfmt='d', floatfmt='g')
+        results = mssqlcli.format_output(
+            'Title',
+            [('abc', 'def')],
+            ['head1', 'head2'],
+            'test status',
+            settings
+        )
         expected = [
-            '-[ RECORD 1 ]-------------------------',
-            'Name | 配列',
-            '-[ RECORD 2 ]-------------------------',
-            'Name | Evening',
-            '-[ RECORD 3 ]-------------------------',
-            'Name | Night',
-            '(3 rows affected)'
+            'Title',
+            '+---------+---------+',
+            '| head1   | head2   |',
+            '|---------+---------|',
+            '| abc     | def     |',
+            '+---------+---------+',
+            'test status'
+        ]
+        assert list(results) == expected
+
+    def test_format_output_live_connection(self):
+        statement = u"""
+            select 1 as [ShiftID], 'Day' as [Name] UNION ALL
+            select 2, N'魚' UNION ALL
+            select 3, 'Night'
+        """
+        try:
+            mssqlcli = create_mssql_cli()
+            result = self.run_and_return_string_from_formatter(mssqlcli, statement)
+            expected = [
+                u'+-----------+--------+',
+                u'| ShiftID   | Name   |',
+                u'|-----------+--------|',
+                u'| 1         | Day    |',
+                u'| 2         | 魚     |',
+                u'| 3         | Night  |',
+                u'+-----------+--------+',
+                u'(3 rows affected)'
             ]
-        assert list(result) == expected
-    finally:
-        shutdown(mssqlcli.mssqlcliclient_main)
+            assert list(result) == expected
+        finally:
+            shutdown(mssqlcli.mssqlcliclient_main)
 
+    def test_format_output_expanded_live_connection(self):
+        statement = u"""
+            select N'配列' as [Name] UNION ALL
+            select 'Evening' UNION ALL
+            select 'Night'
+        """
 
-def test_format_output_auto_expand():
-    mssqlcli = create_mssql_cli()
-    settings = OutputSettings(
-        table_format='psql',
-        dcmlfmt='d',
-        floatfmt='g',
-        max_width=100)
-    table_results = mssqlcli.format_output('Title',
-                                           [('abc', 'def')],
-                                           ['head1', 'head2'],
-                                           'test status',
-                                           settings)
-    table = [
-        'Title',
-        '+---------+---------+',
-        '| head1   | head2   |',
-        '|---------+---------|',
-        '| abc     | def     |',
-        '+---------+---------+',
-        'test status'
-    ]
-    assert list(table_results) == table
-    expanded_results = mssqlcli.format_output(
-        'Title',
-        [('abc', 'def')],
-        ['head1', 'head2'],
-        'test status',
-        settings._replace(max_width=1)
-    )
-    expanded = [
-        'Title',
-        '-[ RECORD 1 ]-------------------------',
-        'head1 | abc',
-        'head2 | def',
-        'test status'
-    ]
-    assert list(expanded_results) == expanded
+        try:
+            mssqlcli = create_mssql_cli()
+            result = self.run_and_return_string_from_formatter(mssqlcli, statement, expanded=True)
+            expected = [
+                '-[ RECORD 1 ]-------------------------',
+                'Name | 配列',
+                '-[ RECORD 2 ]-------------------------',
+                'Name | Evening',
+                '-[ RECORD 3 ]-------------------------',
+                'Name | Night',
+                '(3 rows affected)'
+                ]
+            assert list(result) == expected
+        finally:
+            shutdown(mssqlcli.mssqlcliclient_main)
 
+    def test_format_output_auto_expand(self):
+        mssqlcli = create_mssql_cli()
+        settings = OutputSettings(
+            table_format='psql',
+            dcmlfmt='d',
+            floatfmt='g',
+            max_width=100)
+        table_results = mssqlcli.format_output(
+            'Title',
+            [('abc', 'def')],
+            ['head1', 'head2'],
+            'test status',
+            settings
+        )
+        table = [
+            'Title',
+            '+---------+---------+',
+            '| head1   | head2   |',
+            '|---------+---------|',
+            '| abc     | def     |',
+            '+---------+---------+',
+            'test status'
+        ]
+        assert list(table_results) == table
+        expanded_results = mssqlcli.format_output(
+            'Title',
+            [('abc', 'def')],
+            ['head1', 'head2'],
+            'test status',
+            settings._replace(max_width=1)
+        )
+        expanded = [
+            'Title',
+            '-[ RECORD 1 ]-------------------------',
+            'head1 | abc',
+            'head2 | def',
+            'test status'
+        ]
+        assert list(expanded_results) == expanded
 
-def test_missing_rc_dir(tmpdir):
-    try:
-        rcfile = str(tmpdir.join("subdir").join("rcfile"))
-        mssqlcli = create_mssql_cli(mssqlclirc_file=rcfile)
-        assert os.path.exists(rcfile)
-    finally:
-        mssqlcli.sqltoolsclient.shutdown()
+    def test_missing_rc_dir(self):
+        try:
+            rcfilePath = getTempDir('subdir', 'rcfile')
+            mssqlcli = create_mssql_cli(mssqlclirc_file=rcfilePath)
+            assert os.path.exists(rcfilePath)
+        finally:
+            mssqlcli.sqltoolsclient.shutdown()
 
+    def run_and_return_string_from_formatter(self, mssql_cli, sql, join=False, expanded=False):
+        """
+        Return string output for the sql to be run.
+        """
+        mssql_cli.connect_to_database()
+        mssql_cli_client = mssql_cli.mssqlcliclient_main
+        for rows, col, message, query, is_error in mssql_cli_client.execute_query(sql):
+            settings = OutputSettings(
+                table_format='psql',
+                dcmlfmt='d',
+                floatfmt='g',
+                expanded=expanded
+            )
+            formatted = mssql_cli.format_output(None, rows, col, message, settings)
+            if join:
+                formatted = '\n'.join(formatted)
 
-def run_and_return_string_from_formatter(mssql_cli, sql, join=False, expanded=False):
-    """
-    Return string output for the sql to be run.
-    """
-    mssql_cli.connect_to_database()
-    mssql_cli_client = mssql_cli.mssqlcliclient_main
-    for rows, col, message, query, is_error in mssql_cli_client.execute_query(sql):
-        settings = OutputSettings(table_format='psql',
-                                  dcmlfmt='d',
-                                  floatfmt='g',
-                                  expanded=expanded)
-        formatted = mssql_cli.format_output(None, rows, col, message, settings)
-        if join:
-            formatted = '\n'.join(formatted)
-
-        return formatted
+            return formatted


### PR DESCRIPTION
Fixed broken unit test 'test_main.py'
Failed unit tests in `test_main.py`:
* test_history_file_not_store_credentials
  * Cause: 
    * `file_history` object does not have `append()` method but `append_string()`
    * `file_history` object is not collection type so `len(file_history)` fails.

* test_missing_rc_dir
  * Cause: 
    * Wong method was used for building filepath --> `str(tmpdir.join("subdir").join("rcfile"))`

 Changed `test_fuzzy_completion.py` to use unittest framework