### PR TITLE
Fixed broken unit tests in 'test_sqlcompletion.py' and made non-class type unit tests into class type

### DIFF
--- a/mssqlcli/jsonrpc/contracts/tests/test_json_rpc_contracts.py
+++ b/mssqlcli/jsonrpc/contracts/tests/test_json_rpc_contracts.py
@@ -18,7 +18,7 @@ class JSONRPCContractsTests(unittest.TestCase):
             Verify a successful connection response
         """
 
-        with open(self.get_test_baseline(
+        with open(self.get_baseline(\
                   u'test_simple_query.txt'),
                   u'r+b',
                   buffering=0) as response_file:
@@ -50,7 +50,7 @@ class JSONRPCContractsTests(unittest.TestCase):
         """
            Verify a successful query execute response for "select * from HumanResources.Department"
         """
-        with open(self.get_test_baseline(
+        with open(self.get_baseline(\
                   u'test_simple_query.txt'),
                   u'r+b',
                   buffering=0) as response_file:
@@ -78,7 +78,7 @@ class JSONRPCContractsTests(unittest.TestCase):
         """
             Test the retrieval of the actual rows for "select * from HumanResources.Department"
         """
-        with open(self.get_test_baseline(
+        with open(self.get_baseline(\
                   u'test_simple_query.txt'),
                   u'r+b',
                   buffering=0) as response_file:
@@ -106,7 +106,7 @@ class JSONRPCContractsTests(unittest.TestCase):
         """
             Verify a query execute request never retrieves query request responses for a different query.
         """
-        with open(self.get_test_baseline(
+        with open(self.get_baseline(\
                   u'test_query_retrieve_correct_response.txt'),
                   u'r+b',
                   buffering=0) as response_file:
@@ -135,7 +135,7 @@ class JSONRPCContractsTests(unittest.TestCase):
         """
             Verify a failed query execute response for "select * from [HumanResources.Department"
         """
-        with open(self.get_test_baseline(
+        with open(self.get_baseline(\
                   u'test_malformed_query.txt'),
                   u'r+b',
                   buffering=0) as response_file:
@@ -231,7 +231,7 @@ class JSONRPCContractsTests(unittest.TestCase):
         self.assertEqual(query_row_count, expected_row_count)
         self.assertEqual(query_error_events, expected_error_count)
 
-    def get_test_baseline(self, file_name):
+    def get_baseline(self, file_name):
         """
         Helper method to get baseline file.
         """

--- a/mssqlcli/packages/parseutils/tables.py
+++ b/mssqlcli/packages/parseutils/tables.py
@@ -43,12 +43,6 @@ def extract_from_part(parsed, stop_at_punctuation=True):
                 # Also 'SELECT * FROM abc JOIN def' will trigger this elif
                 # condition. So we need to ignore the keyword JOIN and its variants
                 # INNER JOIN, FULL OUTER JOIN, etc.
-                
-                # Unlikely in Python 2, StopIteration is converted into a RuntimeError
-                # when code runs 'raise StopIteration' in Python 3.
-                # Generators which explicitly raise StopIteration can generally be
-                # changed to simply return instead.
-                # (https://www.python.org/dev/peps/pep-0479/)
                 return
             elif item.ttype is Keyword and (
                     not item.value.upper() == 'FROM') and (

--- a/mssqlcli/packages/parseutils/tables.py
+++ b/mssqlcli/packages/parseutils/tables.py
@@ -35,15 +35,21 @@ def extract_from_part(parsed, stop_at_punctuation=True):
                 for x in extract_from_part(item, stop_at_punctuation):
                     yield x
             elif stop_at_punctuation and item.ttype is Punctuation:
-                raise StopIteration
-            # An incomplete nested select won't be recognized correctly as a
-            # sub-select. eg: 'SELECT * FROM (SELECT id FROM user'. This causes
-            # the second FROM to trigger this elif condition resulting in a
-            # StopIteration. So we need to ignore the keyword if the keyword
-            # FROM.
-            # Also 'SELECT * FROM abc JOIN def' will trigger this elif
-            # condition. So we need to ignore the keyword JOIN and its variants
-            # INNER JOIN, FULL OUTER JOIN, etc.
+                # An incomplete nested select won't be recognized correctly as a
+                # sub-select. eg: 'SELECT * FROM (SELECT id FROM user'. This causes
+                # the second FROM to trigger this elif condition resulting in a
+                # StopIteration. So we need to ignore the keyword if the keyword
+                # FROM.
+                # Also 'SELECT * FROM abc JOIN def' will trigger this elif
+                # condition. So we need to ignore the keyword JOIN and its variants
+                # INNER JOIN, FULL OUTER JOIN, etc.
+                
+                # Unlikely in Python 2, StopIteration is converted into a RuntimeError
+                # when code runs 'raise StopIteration' in Python 3.
+                # Generators which explicitly raise StopIteration can generally be
+                # changed to simply return instead.
+                # (https://www.python.org/dev/peps/pep-0479/)
+                return
             elif item.ttype is Keyword and (
                     not item.value.upper() == 'FROM') and (
                     not item.value.upper().endswith('JOIN')):

--- a/tests/test_prioritization.py
+++ b/tests/test_prioritization.py
@@ -1,20 +1,22 @@
 from mssqlcli.packages.prioritization import PrevalenceCounter
+import unittest
 
+class PrioritizationTests(unittest.TestCase):
 
-def test_prevalence_counter():
-    counter = PrevalenceCounter()
-    sql = '''SELECT * FROM foo WHERE bar GROUP BY baz;
-             select * from foo;
-             SELECT * FROM foo WHERE bar GROUP
-             BY baz'''
-    counter.update(sql)
+    def test_prevalence_counter(self):
+        counter = PrevalenceCounter()
+        sql = '''SELECT * FROM foo WHERE bar GROUP BY baz;
+                select * from foo;
+                SELECT * FROM foo WHERE bar GROUP
+                BY baz'''
+        counter.update(sql)
 
-    keywords = ['SELECT', 'FROM', 'GROUP BY']
-    expected = [3, 3, 2]
-    kw_counts = [counter.keyword_count(x) for x in keywords]
-    assert kw_counts == expected
-    assert counter.keyword_count('NOSUCHKEYWORD') == 0
+        keywords = ['SELECT', 'FROM', 'GROUP BY']
+        expected = [3, 3, 2]
+        kw_counts = [counter.keyword_count(x) for x in keywords]
+        assert kw_counts == expected
+        assert counter.keyword_count('NOSUCHKEYWORD') == 0
 
-    names = ['foo', 'bar', 'baz']
-    name_counts = [counter.name_count(x) for x in names]
-    assert name_counts == [3, 2, 2]
+        names = ['foo', 'bar', 'baz']
+        name_counts = [counter.name_count(x) for x in names]
+        assert name_counts == [3, 2, 2]

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -1,56 +1,44 @@
+import unittest
 from mssqlcli.mssql_cli import MssqlCli
 from mssqltestutils import create_mssql_cli_options
 
+class RowLimitTests(unittest.TestCase):
 
-DEFAULT_OPTIONS = create_mssql_cli_options()
-DEFAULT = MssqlCli(DEFAULT_OPTIONS).row_limit
-LIMIT = DEFAULT + 1000
+    DEFAULT_OPTIONS = create_mssql_cli_options()
+    DEFAULT = MssqlCli(DEFAULT_OPTIONS).row_limit
+    LIMIT = DEFAULT + 1000
 
-low_count = 1
-over_default = DEFAULT + 1
-over_limit = LIMIT + 1
+    low_count = 1
+    over_default = DEFAULT + 1
+    over_limit = LIMIT + 1
 
+    def test_default_row_limit(self):
+        cli = MssqlCli(self.DEFAULT_OPTIONS)
+        stmt = "SELECT * FROM students"
+        result = cli._should_show_limit_prompt(stmt, ['row']*self.low_count)
+        assert result is False
 
-def test_default_row_limit():
-    cli = MssqlCli(DEFAULT_OPTIONS)
-    stmt = "SELECT * FROM students"
-    result = cli._should_show_limit_prompt(stmt, ['row']*low_count)
-    assert result is False
+        result = cli._should_show_limit_prompt(stmt, ['row']*self.over_default)
+        assert result is True
 
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_default)
-    assert result is True
+    def test_no_limit(self):
+        cli_options = create_mssql_cli_options(row_limit=0)
+        cli = MssqlCli(cli_options)
+        assert cli.row_limit is 0
+        stmt = "SELECT * FROM students"
 
+        result = cli._should_show_limit_prompt(stmt, ['row']*self.over_limit)
+        assert result is False
 
-def test_set_row_limit():
-    cli_options = create_mssql_cli_options(row_limit=LIMIT)
-    cli = MssqlCli(cli_options)
-    stmt = "SELECT * FROM students"
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_default)
-    assert result is False
+    def test_row_limit_on_non_select(self):
+        cli = MssqlCli(self.DEFAULT_OPTIONS)
+        stmt = "UPDATE students set name='Boby'"
+        result = cli._should_show_limit_prompt(stmt, None)
+        assert result is False
 
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
-    assert result is True
-
-
-def test_no_limit():
-    cli_options = create_mssql_cli_options(row_limit=0)
-    cli = MssqlCli(cli_options)
-    assert cli.row_limit is 0
-    stmt = "SELECT * FROM students"
-
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_limit)
-    assert result is False
-
-
-def test_row_limit_on_non_select():
-    cli = MssqlCli(DEFAULT_OPTIONS)
-    stmt = "UPDATE students set name='Boby'"
-    result = cli._should_show_limit_prompt(stmt, None)
-    assert result is False
-
-    cli_options = create_mssql_cli_options(row_limit=0)
-    assert cli_options.row_limit is 0
-    cli = MssqlCli(cli_options)
-    result = cli._should_show_limit_prompt(stmt, ['row']*over_default)
-    assert cli.row_limit is 0
-    assert result is False
+        cli_options = create_mssql_cli_options(row_limit=0)
+        assert cli_options.row_limit is 0
+        cli = MssqlCli(cli_options)
+        result = cli._should_show_limit_prompt(stmt, ['row']*self.over_default)
+        assert cli.row_limit is 0
+        assert result is False

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -2,675 +2,716 @@ from mssqlcli.packages.sqlcompletion import (
     suggest_type, Special, Database, Schema, Table, Column, View, Keyword,
     FromClauseItem, Function, Datatype, Alias, JoinCondition, Join)
 from mssqlcli.packages.parseutils.tables import TableReference
-import pytest
+import sys
+import unittest
+
+class SqlCompletionTests(unittest.TestCase):
+
+    def cols_etc(self, table, schema=None, alias=None, is_function=False, parent=None, \
+                last_keyword=None):
+        """Returns the expected select-clause suggestions for a single-table
+        select."""
+        return set([
+            Column(table_refs=(TableReference(schema, table, alias, is_function),), \
+                qualifiable=True),
+            Function(schema=parent),
+            Keyword(last_keyword)
+        ])
 
 
-def cols_etc(table, schema=None, alias=None, is_function=False, parent=None,
-             last_keyword=None):
-    """Returns the expected select-clause suggestions for a single-table
-    select."""
-    return set([
-        Column(table_refs=(TableReference(schema, table, alias, is_function),),
-               qualifiable=True),
-        Function(schema=parent),
-        Keyword(last_keyword)])
+    def test_select_suggests_cols_with_visible_table_scope(self):
+        suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
+        assert set(suggestions) == self.cols_etc('tabl', last_keyword='SELECT')
 
 
-def test_select_suggests_cols_with_visible_table_scope():
-    suggestions = suggest_type('SELECT  FROM tabl', 'SELECT ')
-    assert set(suggestions) == cols_etc('tabl', last_keyword='SELECT')
+    def test_select_suggests_cols_with_qualified_table_scope(self):
+        suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
+        assert set(suggestions) == self.cols_etc('tabl', 'sch', last_keyword='SELECT')
 
 
-def test_select_suggests_cols_with_qualified_table_scope():
-    suggestions = suggest_type('SELECT  FROM sch.tabl', 'SELECT ')
-    assert set(suggestions) == cols_etc('tabl', 'sch', last_keyword='SELECT')
+    def test_cte_does_not_crash(self):
+        sql = ('WITH CTE AS (SELECT F.* FROM Foo F WHERE F.Bar > 23) ' \
+            + 'SELECT C.* FROM CTE C WHERE C.FooID BETWEEN 123 AND 234;')
+        for i in range(len(sql)):
+            suggest_type(sql[:i+1], sql[:i+1])
 
 
-def test_cte_does_not_crash():
-    sql = 'WITH CTE AS (SELECT F.* FROM Foo F WHERE F.Bar > 23) SELECT C.* FROM CTE C WHERE C.FooID BETWEEN 123 AND 234;'
-    for i in range(len(sql)):
-        suggestions = suggest_type(sql[:i+1], sql[:i+1])
+    def test_where_suggests_columns_functions_quoted_table(self):
+        expressions = [
+            'SELECT * FROM "tabl" WHERE '
+        ]
+        for expression in expressions:
+            expected = self.cols_etc('tabl', alias='"tabl"', last_keyword='WHERE')
+            suggestions = suggest_type(expression, expression)
+            assert expected == set(suggestions)
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM "tabl" WHERE ',
-])
-def test_where_suggests_columns_functions_quoted_table(expression):
-    expected = cols_etc('tabl', alias='"tabl"', last_keyword='WHERE')
-    suggestions = suggest_type(expression, expression)
-    assert expected == set(suggestions)
+    def test_where_suggests_columns_functions(self):
+        expressions = [
+            'INSERT INTO OtherTabl(ID, Name) SELECT * FROM tabl WHERE ',
+            'INSERT INTO OtherTabl SELECT * FROM tabl WHERE ',
+            'SELECT * FROM tabl WHERE ',
+            'SELECT * FROM tabl WHERE (',
+            'SELECT * FROM tabl WHERE foo = ',
+            'SELECT * FROM tabl WHERE bar OR ',
+            'SELECT * FROM tabl WHERE foo = 1 AND ',
+            'SELECT * FROM tabl WHERE (bar > 10 AND ',
+            'SELECT * FROM tabl WHERE (bar AND (baz OR (qux AND (',
+            'SELECT * FROM tabl WHERE 10 < ',
+            'SELECT * FROM tabl WHERE foo BETWEEN ',
+            'SELECT * FROM tabl WHERE foo BETWEEN foo AND ',
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == self.cols_etc('tabl', last_keyword='WHERE')
 
 
-@pytest.mark.parametrize('expression', [
-    'INSERT INTO OtherTabl(ID, Name) SELECT * FROM tabl WHERE ',
-    'INSERT INTO OtherTabl SELECT * FROM tabl WHERE ',
-    'SELECT * FROM tabl WHERE ',
-    'SELECT * FROM tabl WHERE (',
-    'SELECT * FROM tabl WHERE foo = ',
-    'SELECT * FROM tabl WHERE bar OR ',
-    'SELECT * FROM tabl WHERE foo = 1 AND ',
-    'SELECT * FROM tabl WHERE (bar > 10 AND ',
-    'SELECT * FROM tabl WHERE (bar AND (baz OR (qux AND (',
-    'SELECT * FROM tabl WHERE 10 < ',
-    'SELECT * FROM tabl WHERE foo BETWEEN ',
-    'SELECT * FROM tabl WHERE foo BETWEEN foo AND ',
-])
-def test_where_suggests_columns_functions(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == cols_etc('tabl', last_keyword='WHERE')
+    def test_where_in_suggests_columns(self):
+        expressions = [
+            'SELECT * FROM tabl WHERE foo IN (',
+            'SELECT * FROM tabl WHERE foo IN (bar, '
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == self.cols_etc('tabl', last_keyword='WHERE')
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM tabl WHERE foo IN (',
-    'SELECT * FROM tabl WHERE foo IN (bar, ',
-])
-def test_where_in_suggests_columns(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == cols_etc('tabl', last_keyword='WHERE')
+    def test_after_as(self):
+        expressions = [
+            'SELECT 1 AS ',
+            'SELECT 1 FROM tabl AS '
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set()
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT 1 AS ',
-    'SELECT 1 FROM tabl AS ',
-])
-def test_after_as(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set()
+    def test_where_equals_any_suggests_columns_or_keywords(self):
+        text = 'SELECT * FROM tabl WHERE foo = ANY('
+        suggestions = suggest_type(text, text)
+        assert set(suggestions) == self.cols_etc('tabl', last_keyword='WHERE')
 
 
-def test_where_equals_any_suggests_columns_or_keywords():
-    text = 'SELECT * FROM tabl WHERE foo = ANY('
-    suggestions = suggest_type(text, text)
-    assert set(suggestions) == cols_etc('tabl', last_keyword='WHERE')
+    def test_lparen_suggests_cols(self):
+        suggestion = suggest_type('SELECT MAX( FROM tbl', 'SELECT MAX(')
+        assert set(suggestion) == set([
+            Column(table_refs=((None, 'tbl', None, False),), qualifiable=True)])
 
 
-def test_lparen_suggests_cols():
-    suggestion = suggest_type('SELECT MAX( FROM tbl', 'SELECT MAX(')
-    assert set(suggestion) == set([
-        Column(table_refs=((None, 'tbl', None, False),), qualifiable=True)])
+    def test_select_suggests_cols_and_funcs(self):
+        suggestions = suggest_type('SELECT ', 'SELECT ')
+        assert set(suggestions) == set([
+            Column(table_refs=(), qualifiable=True),
+            Function(schema=None),
+            Keyword('SELECT'),
+        ])
 
 
-def test_select_suggests_cols_and_funcs():
-    suggestions = suggest_type('SELECT ', 'SELECT ')
-    assert set(suggestions) == set([
-        Column(table_refs=(), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT'),
-    ])
+    def test_suggests_tables_views_and_schemas(self):
+        expressions = [
+            'INSERT INTO ',
+            'COPY ',
+            'UPDATE ',
+            'DESCRIBE '
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set([
+                Table(schema=None),
+                View(schema=None),
+                Schema(),
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'INSERT INTO ',
-    'COPY ',
-    'UPDATE ',
-    'DESCRIBE ',
-])
-def test_suggests_tables_views_and_schemas(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set([
-        Table(schema=None),
-        View(schema=None),
-        Schema(),
-    ])
+    def test_suggest_tables_views_schemas_and_functions(self):
+        expressions = [
+            'SELECT * FROM '
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set([
+                FromClauseItem(schema=None),
+                Schema()
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM ',
-])
-def test_suggest_tables_views_schemas_and_functions(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema()
-    ])
+    def test_suggest_after_join_with_two_tables(self):
+        expressions = [
+            'SELECT * FROM foo JOIN bar on bar.barid = foo.barid JOIN ',
+            'SELECT * FROM foo JOIN bar USING (barid) JOIN '
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            tables = tuple([(None, 'foo', None, False), (None, 'bar', None, False)])
+            assert set(suggestions) == set([
+                FromClauseItem(schema=None, table_refs=tables),
+                Join(tables, None),
+                Schema(),
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo JOIN bar on bar.barid = foo.barid JOIN ',
-    'SELECT * FROM foo JOIN bar USING (barid) JOIN '
-])
-def test_suggest_after_join_with_two_tables(expression):
-    suggestions = suggest_type(expression, expression)
-    tables = tuple([(None, 'foo', None, False), (None, 'bar', None, False)])
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None, table_refs=tables),
-        Join(tables, None),
-        Schema(),
-    ])
+    def test_suggest_after_join_with_one_table(self):
+        expressions = [
+            'SELECT * FROM foo JOIN ',
+            'SELECT * FROM foo JOIN bar'
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            tables = ((None, 'foo', None, False),)
+            assert set(suggestions) == set([
+                FromClauseItem(schema=None, table_refs=tables),
+                Join(((None, 'foo', None, False),), None),
+                Schema(),
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo JOIN ',
-    'SELECT * FROM foo JOIN bar'
-])
-def test_suggest_after_join_with_one_table(expression):
-    suggestions = suggest_type(expression, expression)
-    tables = ((None, 'foo', None, False),)
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None, table_refs=tables),
-        Join(((None, 'foo', None, False),), None),
-        Schema(),
-    ])
+    def test_suggest_qualified_tables_and_views(self):
+        expressions = [
+            'INSERT INTO sch.',
+            'COPY sch.',
+            'DESCRIBE sch.'
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set([
+                Table(schema='sch'),
+                View(schema='sch'),
+            ])
+
+    def test_suggest_qualified_aliasable_tables_and_views(self):
+        expressions = [
+            'UPDATE sch.'
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set([
+                Table(schema='sch'),
+                View(schema='sch'),
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'INSERT INTO sch.',
-    'COPY sch.',
-    'DESCRIBE sch.',
-])
-def test_suggest_qualified_tables_and_views(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set([
-        Table(schema='sch'),
-        View(schema='sch'),
-    ])
+    def test_suggest_qualified_tables_views_and_functions(self):
+        expressions = [
+            'SELECT * FROM sch.',
+            'SELECT * FROM sch."',
+            'SELECT * FROM sch."foo',
+            'SELECT * FROM "sch".',
+            'SELECT * FROM "sch"."'
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            assert set(suggestions) == set([FromClauseItem(schema='sch')])
 
 
-@pytest.mark.parametrize('expression', [
-    'UPDATE sch.',
-])
-def test_suggest_qualified_aliasable_tables_and_views(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set([
-        Table(schema='sch'),
-        View(schema='sch'),
-    ])
+    def test_suggest_qualified_tables_views_functions_and_joins(self):
+        expressions = [
+            'SELECT * FROM foo JOIN sch.'
+        ]
+        for expression in expressions:
+            suggestions = suggest_type(expression, expression)
+            tbls = tuple([(None, 'foo', None, False)])
+            assert set(suggestions) == set([
+                FromClauseItem(schema='sch', table_refs=tbls),
+                Join(tbls, 'sch'),
+            ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM sch.',
-    'SELECT * FROM sch."',
-    'SELECT * FROM sch."foo',
-    'SELECT * FROM "sch".',
-    'SELECT * FROM "sch"."',
-])
-def test_suggest_qualified_tables_views_and_functions(expression):
-    suggestions = suggest_type(expression, expression)
-    assert set(suggestions) == set([FromClauseItem(schema='sch')])
+    def test_truncate_suggests_tables_and_schemas(self):
+        suggestions = suggest_type('TRUNCATE ', 'TRUNCATE ')
+        assert set(suggestions) == set([
+            Table(schema=None),
+            Schema()])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo JOIN sch.',
-])
-def test_suggest_qualified_tables_views_functions_and_joins(expression):
-    suggestions = suggest_type(expression, expression)
-    tbls = tuple([(None, 'foo', None, False)])
-    assert set(suggestions) == set([
-        FromClauseItem(schema='sch', table_refs=tbls),
-        Join(tbls, 'sch'),
-    ])
+    def test_truncate_suggests_qualified_tables(self):
+        suggestions = suggest_type('TRUNCATE sch.', 'TRUNCATE sch.')
+        assert set(suggestions) == set([
+            Table(schema='sch')])
 
 
-def test_truncate_suggests_tables_and_schemas():
-    suggestions = suggest_type('TRUNCATE ', 'TRUNCATE ')
-    assert set(suggestions) == set([
-        Table(schema=None),
-        Schema()])
+    def test_distinct_suggests_cols(self):
+        texts = [
+            'SELECT DISTINCT ',
+            'INSERT INTO foo SELECT DISTINCT '
+        ]
+        for text in texts:
+            suggestions = suggest_type(text, text)
+            assert set(suggestions) == set([
+                Column(table_refs=(), local_tables=(), qualifiable=True),
+                Function(schema=None),
+                Keyword('DISTINCT')
+            ])
 
 
-def test_truncate_suggests_qualified_tables():
-    suggestions = suggest_type('TRUNCATE sch.', 'TRUNCATE sch.')
-    assert set(suggestions) == set([
-        Table(schema='sch')])
-
-
-@pytest.mark.parametrize('text', [
-    'SELECT DISTINCT ',
-    'INSERT INTO foo SELECT DISTINCT '
-])
-def test_distinct_suggests_cols(text):
-    suggestions = suggest_type(text, text)
-    assert set(suggestions) == set([
-        Column(table_refs=(), local_tables=(), qualifiable=True),
-        Function(schema=None),
-        Keyword('DISTINCT')
-    ])
-
-
-@pytest.mark.parametrize('text, text_before, last_keyword', [
-    (
-        'SELECT DISTINCT FROM tbl x JOIN tbl1 y',
-        'SELECT DISTINCT',
-        'SELECT',
-    ),
-    (
-        'SELECT * FROM tbl x JOIN tbl1 y ORDER BY ',
-        'SELECT * FROM tbl x JOIN tbl1 y ORDER BY ',
-        'BY',
-    )
-])
-def test_distinct_and_order_by_suggestions_with_aliases(text, text_before,
-                                                        last_keyword):
-    suggestions = suggest_type(text, text_before)
-    assert set(suggestions) == set([
-        Column(
-            table_refs=(
-                TableReference(None, 'tbl', 'x', False),
-                TableReference(None, 'tbl1', 'y', False),
+    def test_distinct_and_order_by_suggestions_with_aliases(self):
+        test_args = [
+            (
+                'SELECT DISTINCT FROM tbl x JOIN tbl1 y',
+                'SELECT DISTINCT',
+                'SELECT',
             ),
-            local_tables=(),
-            qualifiable=True
-        ),
-        Function(schema=None),
-        Keyword(last_keyword)
-    ])
+            (
+                'SELECT * FROM tbl x JOIN tbl1 y ORDER BY ',
+                'SELECT * FROM tbl x JOIN tbl1 y ORDER BY ',
+                'BY',
+            )
+        ]
+        for arg in test_args:
+            text = arg[0]
+            text_before = arg[1]
+            last_keyword = arg[2]
+
+            suggestions = suggest_type(text, text_before)
+            assert set(suggestions) == set([
+                Column(
+                    table_refs=(
+                        TableReference(None, 'tbl', 'x', False),
+                        TableReference(None, 'tbl1', 'y', False),
+                    ),
+                    local_tables=(),
+                    qualifiable=True
+                ),
+                Function(schema=None),
+                Keyword(last_keyword)
+            ])
 
 
-@pytest.mark.parametrize('text, text_before', [
-    (
-        'SELECT DISTINCT x. FROM tbl x JOIN tbl1 y',
-        'SELECT DISTINCT x.'
-    ),
-    (
-        'SELECT * FROM tbl x JOIN tbl1 y ORDER BY x.',
-        'SELECT * FROM tbl x JOIN tbl1 y ORDER BY x.'
-    )
-])
-def test_distinct_and_order_by_suggestions_with_alias_given(text, text_before):
-    suggestions = suggest_type(text, text_before)
-    assert set(suggestions) == set([
-        Column(
-            table_refs=(TableReference(None, 'tbl', 'x', False),),
-            local_tables=(),
-            qualifiable=False
-        ),
-        Table(schema='x'),
-        View(schema='x'),
-        Function(schema='x'),
-    ])
+    def test_distinct_and_order_by_suggestions_with_alias_given(self):
+        test_args = [
+            (
+                'SELECT DISTINCT x. FROM tbl x JOIN tbl1 y',
+                'SELECT DISTINCT x.'
+            ),
+            (
+                'SELECT * FROM tbl x JOIN tbl1 y ORDER BY x.',
+                'SELECT * FROM tbl x JOIN tbl1 y ORDER BY x.'
+            )
+        ]
+        for arg in test_args:
+            text = arg[0]
+            text_before = arg[1]
+
+            suggestions = suggest_type(text, text_before)
+            assert set(suggestions) == set([
+                Column(
+                    table_refs=(TableReference(None, 'tbl', 'x', False),),
+                    local_tables=(),
+                    qualifiable=False
+                ),
+                Table(schema='x'),
+                View(schema='x'),
+                Function(schema='x'),
+            ])
 
 
-def test_col_comma_suggests_cols():
-    suggestions = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'tbl', None, False),), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT'),
-    ])
+    def test_col_comma_suggests_cols(self):
+        suggestions = suggest_type('SELECT a, b, FROM tbl', 'SELECT a, b,')
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'tbl', None, False),), qualifiable=True),
+            Function(schema=None),
+            Keyword('SELECT'),
+        ])
 
 
-def test_table_comma_suggests_tables_and_schemas():
-    suggestions = suggest_type('SELECT a, b FROM tbl1, ',
-            'SELECT a, b FROM tbl1, ')
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
+    def test_table_comma_suggests_tables_and_schemas(self):
+        suggestions = suggest_type('SELECT a, b FROM tbl1, ', \
+                'SELECT a, b FROM tbl1, ')
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
 
 
-def test_into_suggests_tables_and_schemas():
-    suggestion = suggest_type('INSERT INTO ', 'INSERT INTO ')
-    assert set(suggestion) == set([
-        Table(schema=None),
-        View(schema=None),
-        Schema(),
-    ])
+    def test_into_suggests_tables_and_schemas(self):
+        suggestion = suggest_type('INSERT INTO ', 'INSERT INTO ')
+        assert set(suggestion) == set([
+            Table(schema=None),
+            View(schema=None),
+            Schema(),
+        ])
 
 
-@pytest.mark.parametrize('text', [
-    'INSERT INTO abc (',
-    'INSERT INTO abc () SELECT * FROM hij;',
-])
-def test_insert_into_lparen_suggests_cols(text):
-    suggestions = suggest_type(text, 'INSERT INTO abc (')
-    assert suggestions == (
-        Column(
-            table_refs=((None, 'abc', None, False),),
-            context='insert'
-        ),
-    )
+    def test_insert_into_lparen_suggests_cols(self):
+        texts = [
+            'INSERT INTO abc (',
+            'INSERT INTO abc () SELECT * FROM hij;',
+        ]
+        for text in texts:
+            suggestions = suggest_type(text, 'INSERT INTO abc (')
+            assert suggestions == (
+                Column(
+                    table_refs=((None, 'abc', None, False),),
+                    context='insert'
+                ),
+            )
 
 
-def test_insert_into_lparen_partial_text_suggests_cols():
-    suggestions = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
-    assert suggestions == (
-        Column(
-            table_refs=((None, 'abc', None, False),),
-            context='insert'
-        ),
-    )
+    def test_insert_into_lparen_partial_text_suggests_cols(self):
+        suggestions = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
+        assert suggestions == (
+            Column(
+                table_refs=((None, 'abc', None, False),),
+                context='insert'
+            ),
+        )
 
 
-def test_insert_into_lparen_comma_suggests_cols():
-    suggestions = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
-    assert suggestions == (
-        Column(
-            table_refs=((None, 'abc', None, False),),
-            context='insert'
-        ),
-    )
+    def test_insert_into_lparen_comma_suggests_cols(self):
+        suggestions = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
+        assert suggestions == (
+            Column(
+                table_refs=((None, 'abc', None, False),),
+                context='insert'
+            ),
+        )
 
 
-def test_partially_typed_col_name_suggests_col_names():
-    suggestions = suggest_type('SELECT * FROM tabl WHERE col_n',
+    def test_partially_typed_col_name_suggests_col_names(self):
+        suggestions = suggest_type('SELECT * FROM tabl WHERE col_n', \
             'SELECT * FROM tabl WHERE col_n')
-    assert set(suggestions) == cols_etc('tabl', last_keyword='WHERE')
+        assert set(suggestions) == self.cols_etc('tabl', last_keyword='WHERE')
 
 
-def test_dot_suggests_cols_of_a_table_or_schema_qualified_table():
-    suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'tabl', None, False),)),
-        Table(schema='tabl'),
-        View(schema='tabl'),
-        Function(schema='tabl'),
-    ])
+    def test_dot_suggests_cols_of_a_table_or_schema_qualified_table(self):
+        suggestions = suggest_type('SELECT tabl. FROM tabl', 'SELECT tabl.')
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'tabl', None, False),)),
+            Table(schema='tabl'),
+            View(schema='tabl'),
+            Function(schema='tabl'),
+        ])
 
 
-@pytest.mark.parametrize('sql', [
-    'SELECT t1. FROM tabl1 t1',
-    'SELECT t1. FROM tabl1 t1, tabl2 t2',
-    'SELECT t1. FROM "tabl1" t1',
-    'SELECT t1. FROM "tabl1" t1, "tabl2" t2',
-    ])
-def test_dot_suggests_cols_of_an_alias(sql):
-    suggestions = suggest_type(sql, 'SELECT t1.')
-    assert set(suggestions) == set([
-        Table(schema='t1'),
-        View(schema='t1'),
-        Column(table_refs=((None, 'tabl1', 't1', False),)),
-        Function(schema='t1'),
-    ])
+    def test_dot_suggests_cols_of_an_alias(self):
+        sqls = [
+            'SELECT t1. FROM tabl1 t1',
+            'SELECT t1. FROM tabl1 t1, tabl2 t2',
+            'SELECT t1. FROM "tabl1" t1',
+            'SELECT t1. FROM "tabl1" t1, "tabl2" t2',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, 'SELECT t1.')
+            assert set(suggestions) == set([
+                Table(schema='t1'),
+                View(schema='t1'),
+                Column(table_refs=((None, 'tabl1', 't1', False),)),
+                Function(schema='t1'),
+            ])
 
 
-@pytest.mark.parametrize('sql', [
-    'SELECT * FROM tabl1 t1 WHERE t1.',
-    'SELECT * FROM tabl1 t1, tabl2 t2 WHERE t1.',
-    'SELECT * FROM "tabl1" t1 WHERE t1.',
-    'SELECT * FROM "tabl1" t1, tabl2 t2 WHERE t1.',
-    ])
-def test_dot_suggests_cols_of_an_alias_where(sql):
-    suggestions = suggest_type(sql, sql)
-    assert set(suggestions) == set([
-        Table(schema='t1'),
-        View(schema='t1'),
-        Column(table_refs=((None, 'tabl1', 't1', False),)),
-        Function(schema='t1'),
-    ])
+    def test_dot_suggests_cols_of_an_alias_where(self):
+        sqls = [
+            'SELECT * FROM tabl1 t1 WHERE t1.',
+            'SELECT * FROM tabl1 t1, tabl2 t2 WHERE t1.',
+            'SELECT * FROM "tabl1" t1 WHERE t1.',
+            'SELECT * FROM "tabl1" t1, tabl2 t2 WHERE t1.',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            assert set(suggestions) == set([
+                Table(schema='t1'),
+                View(schema='t1'),
+                Column(table_refs=((None, 'tabl1', 't1', False),)),
+                Function(schema='t1'),
+            ])
 
 
-def test_dot_col_comma_suggests_cols_or_schema_qualified_table():
-    suggestions = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2',
+    def test_dot_col_comma_suggests_cols_or_schema_qualified_table(self):
+        suggestions = suggest_type('SELECT t1.a, t2. FROM tabl1 t1, tabl2 t2', \
             'SELECT t1.a, t2.')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'tabl2', 't2', False),)),
-        Table(schema='t2'),
-        View(schema='t2'),
-        Function(schema='t2'),
-    ])
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'tabl2', 't2', False),)),
+            Table(schema='t2'),
+            View(schema='t2'),
+            Function(schema='t2'),
+        ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM (',
-    'SELECT * FROM foo WHERE EXISTS (',
-    'SELECT * FROM foo WHERE bar AND NOT EXISTS (',
-])
-def test_sub_select_suggests_keyword(expression):
-    suggestion = suggest_type(expression, expression)
-    assert suggestion == (Keyword(),)
+    def test_sub_select_suggests_keyword(self):
+        expressions = [
+            'SELECT * FROM (',
+            'SELECT * FROM foo WHERE EXISTS (',
+            'SELECT * FROM foo WHERE bar AND NOT EXISTS (',
+        ]
+        for expression in expressions:
+            suggestion = suggest_type(expression, expression)
+            assert suggestion == (Keyword(),)
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM (S',
-    'SELECT * FROM foo WHERE EXISTS (S',
-    'SELECT * FROM foo WHERE bar AND NOT EXISTS (S',
-])
-def test_sub_select_partial_text_suggests_keyword(expression):
-    suggestion = suggest_type(expression, expression)
-    assert suggestion ==(Keyword(),)
+    def test_sub_select_partial_text_suggests_keyword(self):
+        expressions = [
+            'SELECT * FROM (S',
+            'SELECT * FROM foo WHERE EXISTS (S',
+            'SELECT * FROM foo WHERE bar AND NOT EXISTS (S',
+        ]
+        for expression in expressions:
+            suggestion = suggest_type(expression, expression)
+            assert suggestion ==(Keyword(),)
 
 
-def test_outer_table_reference_in_exists_subquery_suggests_columns():
-    q = 'SELECT * FROM foo f WHERE EXISTS (SELECT 1 FROM bar WHERE f.'
-    suggestions = suggest_type(q, q)
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'foo', 'f', False),)),
-        Table(schema='f'),
-        View(schema='f'),
-        Function(schema='f'),
-    ])
+    def test_outer_table_reference_in_exists_subquery_suggests_columns(self):
+        q = 'SELECT * FROM foo f WHERE EXISTS (SELECT 1 FROM bar WHERE f.'
+        suggestions = suggest_type(q, q)
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'foo', 'f', False),)),
+            Table(schema='f'),
+            View(schema='f'),
+            Function(schema='f'),
+        ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM (SELECT * FROM ',
-])
-def test_sub_select_table_name_completion(expression):
-    suggestion = suggest_type(expression, expression)
-    assert set(suggestion) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
+    def test_sub_select_table_name_completion(self):
+        expression = 'SELECT * FROM (SELECT * FROM '
+        suggestion = suggest_type(expression, expression)
+        assert set(suggestion) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
 
 
-@pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo WHERE EXISTS (SELECT * FROM ',
-    'SELECT * FROM foo WHERE bar AND NOT EXISTS (SELECT * FROM ',
-])
-def test_sub_select_table_name_completion_with_outer_table(expression):
-    suggestion = suggest_type(expression, expression)
-    tbls = tuple([(None, 'foo', None, False)])
-    assert set(suggestion) == set([
-        FromClauseItem(schema=None, table_refs=tbls),
-        Schema(),
-    ])
+    def test_sub_select_table_name_completion_with_outer_table(self):
+        expressions = [
+            'SELECT * FROM foo WHERE EXISTS (SELECT * FROM ',
+            'SELECT * FROM foo WHERE bar AND NOT EXISTS (SELECT * FROM ',
+        ]
+        for expression in expressions:
+            suggestion = suggest_type(expression, expression)
+            tbls = tuple([(None, 'foo', None, False)])
+            assert set(suggestion) == set([
+                FromClauseItem(schema=None, table_refs=tbls),
+                Schema(),
+            ])
 
 
-def test_sub_select_col_name_completion():
-    suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc',
+    def test_sub_select_col_name_completion(self):
+        suggestions = suggest_type('SELECT * FROM (SELECT  FROM abc', \
             'SELECT * FROM (SELECT ')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'abc', None, False),), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT'),
-    ])
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'abc', None, False),), qualifiable=True),
+            Function(schema=None),
+            Keyword('SELECT'),
+        ])
 
 
-@pytest.mark.xfail
-def test_sub_select_multiple_col_name_completion():
-    suggestions = suggest_type('SELECT * FROM (SELECT a, FROM abc',
+    def test_sub_select_multiple_col_name_completion(self):
+        suggestions = suggest_type('SELECT * FROM (SELECT a, FROM abc', \
             'SELECT * FROM (SELECT a, ')
-    assert set(suggestions) == cols_etc('abc')
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'a', None, False), (None, 'abc', None, False)), \
+                qualifiable=True),
+            Function(schema=None),
+            Keyword('SELECT'),
+        ])
 
 
-def test_sub_select_dot_col_name_completion():
-    suggestions = suggest_type('SELECT * FROM (SELECT t. FROM tabl t',
+    def test_sub_select_dot_col_name_completion(self):
+        suggestions = suggest_type('SELECT * FROM (SELECT t. FROM tabl t', \
             'SELECT * FROM (SELECT t.')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'tabl', 't', False),)),
-        Table(schema='t'),
-        View(schema='t'),
-        Function(schema='t'),
-    ])
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'tabl', 't', False),)),
+            Table(schema='t'),
+            View(schema='t'),
+            Function(schema='t'),
+        ])
 
 
-@pytest.mark.parametrize('join_type',('', 'INNER', 'LEFT', 'RIGHT OUTER',))
-@pytest.mark.parametrize('tbl_alias',('', 'foo',))
-def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
-    text = 'SELECT * FROM abc {0} {1} JOIN '.format(tbl_alias, join_type)
-    suggestion = suggest_type(text, text)
-    tbls = tuple([(None, 'abc', tbl_alias or None, False)])
-    assert set(suggestion) == set([
-        FromClauseItem(schema=None, table_refs=tbls),
-        Schema(),
-        Join(tbls, None),
-    ])
+    def test_join_suggests_tables_and_schemas(self):
+        join_types = ('', 'INNER', 'LEFT', 'RIGHT OUTER',)
+        tbl_aliases = ('', 'foo',)
+        for join_type in join_types:
+            for tbl_alias in tbl_aliases:
+                text = 'SELECT * FROM abc {0} {1} JOIN '.format(tbl_alias, join_type)
+                suggestion = suggest_type(text, text)
+                tbls = tuple([(None, 'abc', tbl_alias or None, False)])
+                assert set(suggestion) == set([
+                    FromClauseItem(schema=None, table_refs=tbls),
+                    Schema(),
+                    Join(tbls, None),
+                ])
 
 
-def test_left_join_with_comma():
-    text = 'select * from foo f left join bar b,'
-    suggestions = suggest_type(text, text)
-    # tbls should also include (None, 'bar', 'b', False)
-    # but there's a bug with commas
-    tbls = tuple([(None, 'foo', 'f', False)])
-    assert set(suggestions) == set([
-         FromClauseItem(schema=None, table_refs=tbls),
-         Schema(),
-    ])
+    def test_left_join_with_comma(self):
+        text = 'select * from foo f left join bar b,'
+        suggestions = suggest_type(text, text)
+        # tbls should also include (None, 'bar', 'b', False)
+        # but there's a bug with commas
+        tbls = tuple([(None, 'foo', 'f', False)])
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None, table_refs=tbls),
+            Schema(),
+        ])
 
 
-@pytest.mark.parametrize('sql', [
-    'SELECT * FROM abc a JOIN def d ON a.',
-    'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.',
-])
-def test_join_alias_dot_suggests_cols1(sql):
-    suggestions = suggest_type(sql, sql)
-    tables = ((None, 'abc', 'a', False), (None, 'def', 'd', False))
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'abc', 'a', False),)),
-        Table(schema='a'),
-        View(schema='a'),
-        Function(schema='a'),
-        JoinCondition(table_refs=tables, parent=(None, 'abc', 'a', False))
-    ])
+    def test_join_alias_dot_suggests_cols1(self):
+        sqls = [
+            'SELECT * FROM abc a JOIN def d ON a.',
+            'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            tables = ((None, 'abc', 'a', False), (None, 'def', 'd', False))
+            assert set(suggestions) == set([
+                Column(table_refs=((None, 'abc', 'a', False),)),
+                Table(schema='a'),
+                View(schema='a'),
+                Function(schema='a'),
+                JoinCondition(table_refs=tables, parent=(None, 'abc', 'a', False))
+            ])
 
 
-@pytest.mark.parametrize('sql', [
-    'SELECT * FROM abc a JOIN def d ON a.id = d.',
-    'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.id2 = d.',
-])
-def test_join_alias_dot_suggests_cols2(sql):
-    suggestion = suggest_type(sql, sql)
-    assert set(suggestion) == set([
-        Column(table_refs=((None, 'def', 'd', False),)),
-        Table(schema='d'),
-        View(schema='d'),
-        Function(schema='d'),
-    ])
+    def test_join_alias_dot_suggests_cols2(self):
+        sqls = [
+            'SELECT * FROM abc a JOIN def d ON a.id = d.',
+            'SELECT * FROM abc a JOIN def d ON a.id = d.id AND a.id2 = d.',
+        ]
+        for sql in sqls:
+            suggestion = suggest_type(sql, sql)
+            assert set(suggestion) == set([
+                Column(table_refs=((None, 'def', 'd', False),)),
+                Table(schema='d'),
+                View(schema='d'),
+                Function(schema='d'),
+            ])
 
 
-@pytest.mark.parametrize('sql', [
-    'select a.x, b.y from abc a join bcd b on ',
-    '''select a.x, b.y
+    def test_on_suggests_aliases_and_join_conditions(self):
+        sqls = [ \
+'select a.x, b.y from abc a join bcd b on ',
+'''select a.x, b.y
 from abc a
 join bcd b on
 ''',
-    '''select a.x, b.y
+'''select a.x, b.y
 from abc a
 join bcd b
 on ''',
-    'select a.x, b.y from abc a join bcd b on a.id = b.id OR ',
-])
-def test_on_suggests_aliases_and_join_conditions(sql):
-    suggestions = suggest_type(sql, sql)
-    tables = ((None, 'abc', 'a', False), (None, 'bcd', 'b', False))
-    assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None),
-        Alias(aliases=('a', 'b',)),))
+'select a.x, b.y from abc a join bcd b on a.id = b.id OR ' \
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            tables = ((None, 'abc', 'a', False), (None, 'bcd', 'b', False))
+            assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None), \
+                Alias(aliases=('a', 'b',)),))
 
 
-@pytest.mark.parametrize('sql', [
-    'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id AND ',
-    'select abc.x, bcd.y from abc join bcd on ',
-])
-def test_on_suggests_tables_and_join_conditions(sql):
-    suggestions = suggest_type(sql, sql)
-    tables = ((None, 'abc', None, False), (None, 'bcd', None, False))
-    assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None),
-        Alias(aliases=('abc', 'bcd',)),))
+    def test_on_suggests_tables_and_join_conditions(self):
+        sqls = [
+            'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id AND ',
+            'select abc.x, bcd.y from abc join bcd on ',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            tables = ((None, 'abc', None, False), (None, 'bcd', None, False))
+            assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None), \
+                Alias(aliases=('abc', 'bcd',)),))
 
 
-@pytest.mark.parametrize('sql', [
-    'select a.x, b.y from abc a join bcd b on a.id = ',
-    'select a.x, b.y from abc a join bcd b on a.id = b.id AND a.id2 = ',
-])
-def test_on_suggests_aliases_right_side(sql):
-    suggestions = suggest_type(sql, sql)
-    assert suggestions == (Alias(aliases=('a', 'b',)),)
+    def test_on_suggests_aliases_right_side(self):
+        sqls = [
+            'select a.x, b.y from abc a join bcd b on a.id = ',
+            'select a.x, b.y from abc a join bcd b on a.id = b.id AND a.id2 = ',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            assert suggestions == (Alias(aliases=('a', 'b',)),)
 
 
-@pytest.mark.parametrize('sql', [
-    'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id and ',
-    'select abc.x, bcd.y from abc join bcd on ',
-])
-def test_on_suggests_tables_and_join_conditions_right_side(sql):
-    suggestions = suggest_type(sql, sql)
-    tables = ((None, 'abc', None, False), (None, 'bcd', None, False))
-    assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None),
-      Alias(aliases=('abc', 'bcd',)),))
+    def test_on_suggests_tables_and_join_conditions_right_side(self):
+        sqls = [
+            'select abc.x, bcd.y from abc join bcd on abc.id = bcd.id and ',
+            'select abc.x, bcd.y from abc join bcd on ',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            tables = ((None, 'abc', None, False), (None, 'bcd', None, False))
+            assert set(suggestions) == set((JoinCondition(table_refs=tables, parent=None), \
+                Alias(aliases=('abc', 'bcd',)),))
 
 
-@pytest.mark.parametrize('text', (
-    'select * from abc inner join def using (',
-    'select * from abc inner join def using (col1, ',
-    'insert into hij select * from abc inner join def using (',
-    '''insert into hij(x, y, z)
-    select * from abc inner join def using (col1, ''',
-    '''insert into hij (a,b,c)
-    select * from abc inner join def using (col1, ''',
-))
-def test_join_using_suggests_common_columns(text):
-    tables = ((None, 'abc', None, False), (None, 'def', None, False))
-    assert set(suggest_type(text, text)) == set([
-        Column(table_refs=tables, require_last_table=True),])
+    def test_join_using_suggests_common_columns(self):
+        texts = [
+            'select * from abc inner join def using (',
+            'select * from abc inner join def using (col1, ',
+            'insert into hij select * from abc inner join def using (',
+            '''insert into hij(x, y, z)
+            select * from abc inner join def using (col1, ''',
+            '''insert into hij (a,b,c)
+            select * from abc inner join def using (col1, ''',
+        ]
+        for text in texts:
+            tables = ((None, 'abc', None, False), (None, 'def', None, False))
+            assert set(suggest_type(text, text)) == set([
+                Column(table_refs=tables, require_last_table=True),])
 
 
-def test_suggest_columns_after_multiple_joins():
-    sql = '''select * from t1
-            inner join t2 ON
-              t1.id = t2.t1_id
-            inner join t3 ON
-              t2.id = t3.'''
-    suggestions = suggest_type(sql, sql)
-    assert Column(table_refs=((None, 't3', None, False),)) in set(suggestions)
+    def test_suggest_columns_after_multiple_joins(self):
+        sql = '''select * from t1
+                inner join t2 ON
+                t1.id = t2.t1_id
+                inner join t3 ON
+                t2.id = t3.'''
+        suggestions = suggest_type(sql, sql)
+        assert Column(table_refs=((None, 't3', None, False),)) in set(suggestions)
 
 
-def test_2_statements_2nd_current():
-    suggestions = suggest_type('select * from a; select * from ',
-                               'select * from a; select * from ')
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
+    def test_2_statements_2nd_current(self):
+        suggestions = suggest_type('select * from a; select * from ', \
+            'select * from a; select * from ')
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
 
-    suggestions = suggest_type('select * from a; select  from b',
-                               'select * from a; select ')
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'b', None, False),), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT')
-    ])
+        suggestions = suggest_type('select * from a; select  from b', \
+            'select * from a; select ')
+        assert set(suggestions) == set([
+            Column(table_refs=((None, 'b', None, False),), qualifiable=True),
+            Function(schema=None),
+            Keyword('SELECT')
+        ])
 
-    # Should work even if first statement is invalid
-    suggestions = suggest_type('select * from; select * from ',
-                               'select * from; select * from ')
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
-
-
-def test_2_statements_1st_current():
-    suggestions = suggest_type('select * from ; select * from b',
-                               'select * from ')
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
-
-    suggestions = suggest_type('select  from a; select * from b',
-                               'select ')
-    assert set(suggestions) == cols_etc('a', last_keyword='SELECT')
+        # Should work even if first statement is invalid
+        suggestions = suggest_type('select * from; select * from ', \
+            'select * from; select * from ')
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
 
 
-def test_3_statements_2nd_current():
-    suggestions = suggest_type('select * from a; select * from ; select * from c',
-                               'select * from a; select * from ')
-    assert set(suggestions) == set([
-        FromClauseItem(schema=None),
-        Schema(),
-    ])
+    def test_2_statements_1st_current(self):
+        suggestions = suggest_type('select * from ; select * from b', \
+            'select * from ')
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
 
-    suggestions = suggest_type('select * from a; select  from b; select * from c',
-                               'select * from a; select ')
-    assert set(suggestions) == cols_etc('b', last_keyword='SELECT')
+        suggestions = suggest_type('select  from a; select * from b', 'select ')
+        assert set(suggestions) == self.cols_etc('a', last_keyword='SELECT')
 
 
-@pytest.mark.parametrize('text', [
+    def test_3_statements_2nd_current(self):
+        suggestions = suggest_type('select * from a; select * from ; select * from c', \
+            'select * from a; select * from ')
+        assert set(suggestions) == set([
+            FromClauseItem(schema=None),
+            Schema(),
+        ])
+
+        suggestions = suggest_type('select * from a; select  from b; select * from c', \
+            'select * from a; select ')
+        assert set(suggestions) == self.cols_etc('b', last_keyword='SELECT')
+
+
+    def test_statements_in_function_body(self):
+        texts = [ \
 '''
 CREATE OR REPLACE FUNCTION func() RETURNS setof int AS $$
 SELECT  FROM foo;
 SELECT 2 FROM bar;
 $$ language sql;
-    ''',
+    ''', \
     '''create function func2(int, varchar)
 RETURNS text
 language sql AS
@@ -706,24 +747,24 @@ SELECT 3 FROM bar;
 SELECT  FROM foo;
 $func$
 SELECT * FROM qux;
-    '''
-])
-def test_statements_in_function_body(text):
-    suggestions = suggest_type(text, text[:text.find('  ') + 1])
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'foo', None, False),), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT'),
-    ])
+    ''' \
+        ]
+        for text in texts:
+            suggestions = suggest_type(text, text[:text.find('  ') + 1])
+            assert set(suggestions) == set([
+                Column(table_refs=((None, 'foo', None, False),), qualifiable=True),
+                Function(schema=None),
+                Keyword('SELECT'),
+            ])
 
 
-functions = [
+    functions = [ \
 '''
 CREATE OR REPLACE FUNCTION func() RETURNS setof int AS $$
 SELECT 1 FROM foo;
 SELECT 2 FROM bar;
 $$ language sql;
-    ''',
+    ''', \
     '''
 create function func2(int, varchar)
 RETURNS text
@@ -732,204 +773,216 @@ language sql AS
 SELECT 2 FROM bar;
 SELECT 1 FROM foo;
 ';
-    '''
-]
+    ''' \
+    ]
 
 
-@pytest.mark.parametrize('text', functions)
-def test_statements_with_cursor_after_function_body(text):
-    suggestions = suggest_type(text, text[:text.find('; ') + 1])
-    assert set(suggestions) == set([Keyword(), Special()])
+    def test_statements_with_cursor_after_function_body(self):
+        texts = self.functions
+        for text in texts:
+            suggestions = suggest_type(text, text[:text.find('; ') + 1])
+            assert set(suggestions) == set([Keyword(), Special()])
 
 
-@pytest.mark.parametrize('text', functions)
-def test_statements_with_cursor_before_function_body(text):
-    suggestions = suggest_type(text, '')
-    assert set(suggestions) == set([Keyword(), Special()])
+    def test_statements_with_cursor_before_function_body(self):
+        texts = self.functions
+        for text in texts:
+            suggestions = suggest_type(text, '')
+            assert set(suggestions) == set([Keyword(), Special()])
 
 
-def test_create_db_with_template():
-    suggestions = suggest_type('create database foo with template ',
-                               'create database foo with template ')
-
-    assert set(suggestions) == set((Database(),))
-
-
-@pytest.mark.parametrize('initial_text',('', '    ', '\t \t',))
-def test_specials_included_for_initial_completion(initial_text):
-    suggestions = suggest_type(initial_text, initial_text)
-
-    assert set(suggestions) == \
-        set([Keyword(), Special()])
+    def test_create_db_with_template(self):
+        suggestions = suggest_type('create database foo with template ', \
+            'create database foo with template ')
+        assert set(suggestions) == set((Database(),))
 
 
-def test_drop_schema_qualified_table_suggests_only_tables():
-    text = 'DROP TABLE schema_name.table_name'
-    suggestions = suggest_type(text, text)
-    assert suggestions ==(Table(schema='schema_name'),)
+    def test_specials_included_for_initial_completion(self):
+        initial_texts = ('', '    ', '\t \t',)
+        for initial_text in initial_texts:
+            suggestions = suggest_type(initial_text, initial_text)
+            assert set(suggestions) == set([Keyword(), Special()])
 
 
-@pytest.mark.parametrize('text',(',', '  ,', 'sel ,',))
-def test_handle_pre_completion_comma_gracefully(text):
-    suggestions = suggest_type(text, text)
-
-    assert iter(suggestions)
-
-
-def test_drop_schema_suggests_schemas():
-    sql = 'DROP SCHEMA '
-    assert suggest_type(sql, sql) ==(Schema(),)
+    def test_drop_schema_qualified_table_suggests_only_tables(self):
+        text = 'DROP TABLE schema_name.table_name'
+        suggestions = suggest_type(text, text)
+        assert suggestions == (Table(schema='schema_name'),)
 
 
-@pytest.mark.parametrize('text', [
-    'SELECT x::',
-    'SELECT x::y',
-    'SELECT (x + y)::',
-])
-def test_cast_operator_suggests_types(text):
-    assert set(suggest_type(text, text)) == set([
-        Datatype(schema=None),
-        Table(schema=None),
-        Schema()])
+    def test_handle_pre_completion_comma_gracefully(self):
+        texts = (',', '  ,', 'sel ,',)
+        for text in texts:
+            suggestions = suggest_type(text, text)
+            assert iter(suggestions)
 
 
-@pytest.mark.parametrize('text', [
-    'SELECT foo::bar.',
-    'SELECT foo::bar.baz',
-    'SELECT (x + y)::bar.',
-])
-def test_cast_operator_suggests_schema_qualified_types(text):
-    assert set(suggest_type(text, text)) == set([
-        Datatype(schema='bar'),
-        Table(schema='bar')])
+    def test_drop_schema_suggests_schemas(self):
+        sql = 'DROP SCHEMA '
+        assert suggest_type(sql, sql) == (Schema(),)
 
 
-def test_alter_column_type_suggests_types():
-    q = 'ALTER TABLE foo ALTER COLUMN bar TYPE '
-    assert set(suggest_type(q, q)) == set([
-        Datatype(schema=None),
-        Table(schema=None),
-        Schema()])
+    def test_cast_operator_suggests_types(self):
+        texts = [
+            'SELECT x::',
+            'SELECT x::y',
+            'SELECT (x + y)::',
+        ]
+        for text in texts:
+            assert set(suggest_type(text, text)) == set([
+                Datatype(schema=None),
+                Table(schema=None),
+                Schema()])
 
 
-@pytest.mark.parametrize('text', [
-    'CREATE TABLE foo (bar ',
-    'CREATE TABLE foo (bar DOU',
-    'CREATE TABLE foo (bar INT, baz ',
-    'CREATE TABLE foo (bar INT, baz TEXT, qux ',
-    'CREATE FUNCTION foo (bar ',
-    'CREATE FUNCTION foo (bar INT, baz ',
-    'SELECT * FROM foo() AS bar (baz ',
-    'SELECT * FROM foo() AS bar (baz INT, qux ',
-
-    # make sure this doesnt trigger special completion
-    'CREATE TABLE foo (dt d',
-])
-def test_identifier_suggests_types_in_parentheses(text):
-    assert set(suggest_type(text, text)) == set([
-        Datatype(schema=None),
-        Table(schema=None),
-        Schema()])
+    def test_cast_operator_suggests_schema_qualified_types(self):
+        texts = [
+            'SELECT foo::bar.',
+            'SELECT foo::bar.baz',
+            'SELECT (x + y)::bar.',
+        ]
+        for text in texts:
+            assert set(suggest_type(text, text)) == set([
+                Datatype(schema='bar'),
+                Table(schema='bar')])
 
 
-@pytest.mark.parametrize('text', [
-    'SELECT foo ',
-    'SELECT foo FROM bar ',
-    'SELECT foo AS bar ',
-    'SELECT foo bar ',
-    'SELECT * FROM foo AS bar ',
-    'SELECT * FROM foo bar ',
-    'SELECT foo FROM (SELECT bar '
-])
-def test_alias_suggests_keywords(text):
-    suggestions = suggest_type(text, text)
-    assert suggestions ==(Keyword(),)
+    def test_alter_column_type_suggests_types(self):
+        q = 'ALTER TABLE foo ALTER COLUMN bar TYPE '
+        assert set(suggest_type(q, q)) == set([
+            Datatype(schema=None),
+            Table(schema=None),
+            Schema()])
 
 
-def test_invalid_sql():
-    # issue 317
-    text = 'selt *'
-    suggestions = suggest_type(text, text)
-    assert suggestions ==(Keyword(),)
+    def test_identifier_suggests_types_in_parentheses(self):
+        texts = [
+            'CREATE TABLE foo (bar ',
+            'CREATE TABLE foo (bar DOU',
+            'CREATE TABLE foo (bar INT, baz ',
+            'CREATE TABLE foo (bar INT, baz TEXT, qux ',
+            'CREATE FUNCTION foo (bar ',
+            'CREATE FUNCTION foo (bar INT, baz ',
+            'SELECT * FROM foo() AS bar (baz ',
+            'SELECT * FROM foo() AS bar (baz INT, qux ',
+
+            # make sure this doesnt trigger special completion
+            'CREATE TABLE foo (dt d',
+        ]
+        for text in texts:
+            assert set(suggest_type(text, text)) == set([
+                Datatype(schema=None),
+                Table(schema=None),
+                Schema()])
 
 
-@pytest.mark.parametrize('text', [
-    'SELECT * FROM foo where created > now() - ',
-    'select * from foo where bar ',
-])
-def test_suggest_where_keyword(text):
-    # https://github.com/dbcli/mycli/issues/135
-    suggestions = suggest_type(text, text)
-    assert set(suggestions) == cols_etc('foo', last_keyword='WHERE')
+    def test_alias_suggests_keywords(self):
+        texts = [
+            'SELECT foo ',
+            'SELECT foo FROM bar ',
+            'SELECT foo AS bar ',
+            'SELECT foo bar ',
+            'SELECT * FROM foo AS bar ',
+            'SELECT * FROM foo bar ',
+            'SELECT foo FROM (SELECT bar '
+        ]
+        for text in texts:
+            suggestions = suggest_type(text, text)
+            assert suggestions ==(Keyword(),)
 
 
-@pytest.mark.parametrize('text, before, expected', [
-    ('\\ns abc SELECT ', 'SELECT ', [
-        Column(table_refs=(), qualifiable=True),
-        Function(schema=None),
-        Keyword('SELECT')
-    ]),
-    ('\\ns abc SELECT foo ', 'SELECT foo ', (Keyword(),)),
-    ('\\ns abc SELECT t1. FROM tabl1 t1', 'SELECT t1.', [
-        Table(schema='t1'),
-        View(schema='t1'),
-        Column(table_refs=((None, 'tabl1', 't1', False),)),
-        Function(schema='t1')
-    ])
-])
-def test_named_query_completion(text, before, expected):
-    suggestions = suggest_type(text, before)
-    assert set(expected) == set(suggestions)
+    def test_invalid_sql(self):
+        # issue 317
+        text = 'selt *'
+        suggestions = suggest_type(text, text)
+        assert suggestions ==(Keyword(),)
 
 
-def test_select_suggests_fields_from_function():
-    suggestions = suggest_type('SELECT  FROM func()', 'SELECT ')
-    assert set(suggestions) == cols_etc(
-        'func', is_function=True, last_keyword='SELECT')
+    def test_suggest_where_keyword(self):
+        # https://github.com/dbcli/mycli/issues/135
+        texts = [
+            'SELECT * FROM foo where created > now() - ',
+            'select * from foo where bar ',
+        ]
+        for text in texts:
+            suggestions = suggest_type(text, text)
+            assert set(suggestions) == self.cols_etc('foo', last_keyword='WHERE')
 
 
-@pytest.mark.parametrize('sql', [
-    '(',
-])
-def test_leading_parenthesis(sql):
-    # No assertion for now; just make sure it doesn't crash
-    suggest_type(sql, sql)
+    def test_named_query_completion(self):
+        test_args = [
+            ('\\ns abc SELECT ', 'SELECT ', [
+                Column(table_refs=(), qualifiable=True),
+                Function(schema=None),
+                Keyword('SELECT')
+            ]),
+            ('\\ns abc SELECT foo ', 'SELECT foo ', (Keyword(),)),
+            ('\\ns abc SELECT t1. FROM tabl1 t1', 'SELECT t1.', [
+                Table(schema='t1'),
+                View(schema='t1'),
+                Column(table_refs=((None, 'tabl1', 't1', False),)),
+                Function(schema='t1')
+            ])
+        ]
+        for arg in test_args:
+            text = arg[0]
+            before = arg[1]
+            expected = arg[2]
+            suggestions = suggest_type(text, before)
+            assert set(expected) == set(suggestions)
 
 
-@pytest.mark.parametrize('sql', [
-    'select * from "',
-    'select * from "foo',
-])
-def test_ignore_leading_double_quotes(sql):
-    suggestions = suggest_type(sql, sql)
-    assert FromClauseItem(schema=None) in set(suggestions)
+    def test_select_suggests_fields_from_function(self):
+        suggestions = suggest_type('SELECT  FROM func()', 'SELECT ')
+        assert set(suggestions) == self.cols_etc(
+            'func', is_function=True, last_keyword='SELECT')
 
 
-@pytest.mark.parametrize('sql', [
-    'ALTER TABLE foo ALTER COLUMN ',
-    'ALTER TABLE foo ALTER COLUMN bar',
-    'ALTER TABLE foo DROP COLUMN ',
-    'ALTER TABLE foo DROP COLUMN bar',
-])
-def test_column_keyword_suggests_columns(sql):
-    suggestions = suggest_type(sql, sql)
-    assert set(suggestions) == set([
-        Column(table_refs=((None, 'foo', None, False),)),
-    ])
+    def test_leading_parenthesis(self):
+        sqls = [
+            '(',
+        ]
+        for sql in sqls:
+            # No assertion for now; just make sure it doesn't crash
+            suggest_type(sql, sql)
 
 
-def test_handle_unrecognized_kw_generously():
-    sql = 'SELECT * FROM sessions WHERE session = 1 AND '
-    suggestions = suggest_type(sql, sql)
-    expected = Column(table_refs=((None, 'sessions', None, False),),
-                      qualifiable=True)
+    def test_ignore_leading_double_quotes(self):
+        sqls = [
+            'select * from "',
+            'select * from "foo',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            assert FromClauseItem(schema=None) in set(suggestions)
 
-    assert expected in set(suggestions)
+
+    def test_column_keyword_suggests_columns(self):
+        sqls = [
+            'ALTER TABLE foo ALTER COLUMN ',
+            'ALTER TABLE foo ALTER COLUMN bar',
+            'ALTER TABLE foo DROP COLUMN ',
+            'ALTER TABLE foo DROP COLUMN bar',
+        ]
+        for sql in sqls:
+            suggestions = suggest_type(sql, sql)
+            assert set(suggestions) == set([
+                Column(table_refs=((None, 'foo', None, False),)),
+            ])
 
 
-@pytest.mark.parametrize('sql', [
-    'ALTER ',
-    'ALTER TABLE foo ALTER ',
-])
-def test_keyword_after_alter(sql):
-    assert Keyword('ALTER') in set(suggest_type(sql, sql))
+    def test_handle_unrecognized_kw_generously(self):
+        sql = 'SELECT * FROM sessions WHERE session = 1 AND '
+        suggestions = suggest_type(sql, sql)
+        expected = Column(table_refs=((None, 'sessions', None, False),), \
+            qualifiable=True)
+        assert expected in set(suggestions)
+
+
+    def test_keyword_after_alter(self):
+        sqls = [
+            'ALTER ',
+            'ALTER TABLE foo ALTER ',
+        ]
+        for sql in sqls:
+            assert Keyword('ALTER') in set(suggest_type(sql, sql))


### PR DESCRIPTION
* test_json_rpc_contracts.py
  * Renamed `get_test_baseline()` into `get_baseline()` since it was recognized as a unit test case by unit test auto discovery
* tables.py
  * `raise StopIteration` was used previously, which is ok in Python2 but not in Python3. `StopIteration` is converted to `RuntimeError`, and `raise StopIteration` throws exception in Python3. This broke several unit tests in test_sqlcompletion.py running in Python3. Proper way for backward compatibility is using `return` statement. (https://www.python.org/dev/peps/pep-0479/)
* test_prioritization.py and test_rowlimit.py 
  * Converted into class type unit tests
* test_sqlcompletion.py
  * Fixed broken unit tests caused by `StopIteration` RuntimeError in Python3
  * Fixed broken unit test that was disabled: test_sub_select_multiple_col_name_completion
  * Converted into class type unit tests

All tests are passed in both Python2 and 3.