### PR TITLE
Fixed broken functionalities when running on Python2

### DIFF
--- a/mssqlcli/config.py
+++ b/mssqlcli/config.py
@@ -26,12 +26,8 @@ def load_config(usr_cfg, def_cfg=None):
 
 def ensure_dir_exists(path):
     parent_dir = expanduser(dirname(path))
-    try:
+    if not os.path.exists(parent_dir):
         os.makedirs(parent_dir)
-    except OSError as exc:
-        # ignore existing destination (py2 has no exist_ok arg to makedirs)
-        if exc.errno != errno.EEXIST:
-            raise
 
 
 def write_default_config(source, destination, overwrite=False):

--- a/mssqlcli/key_bindings.py
+++ b/mssqlcli/key_bindings.py
@@ -12,7 +12,7 @@ def mssqlcli_bindings(mssql_cli):
     """
     key_bindings = KeyBindings()
 
-    @key_bindings.add('f2')
+    @key_bindings.add(u'f2')
     def _(event):
         """
         Enable/Disable SmartCompletion Mode.
@@ -20,7 +20,7 @@ def mssqlcli_bindings(mssql_cli):
         _logger.debug('Detected F2 key.')
         mssql_cli.completer.smart_completion = not mssql_cli.completer.smart_completion
 
-    @key_bindings.add('f3')
+    @key_bindings.add(u'f3')
     def _(event):
         """
         Enable/Disable Multiline Mode.
@@ -28,7 +28,7 @@ def mssqlcli_bindings(mssql_cli):
         _logger.debug('Detected F3 key.')
         mssql_cli.multiline = not mssql_cli.multiline
 
-    @key_bindings.add('f4')
+    @key_bindings.add(u'f4')
     def _(event):
         """
         Toggle between Vi and Emacs mode.
@@ -37,7 +37,7 @@ def mssqlcli_bindings(mssql_cli):
         mssql_cli.vi_mode = not mssql_cli.vi_mode
         event.app.editing_mode = EditingMode.VI if mssql_cli.vi_mode else EditingMode.EMACS
 
-    @key_bindings.add('tab')
+    @key_bindings.add(u'tab')
     def _(event):
         """
         Force autocompletion at cursor.
@@ -49,7 +49,7 @@ def mssqlcli_bindings(mssql_cli):
         else:
             b.start_completion(select_first=True)
 
-    @key_bindings.add('c-space')
+    @key_bindings.add(u'c-space')
     def _(event):
         """
         Initialize autocompletion at cursor.
@@ -67,7 +67,7 @@ def mssqlcli_bindings(mssql_cli):
         else:
             b.start_completion(select_first=False)
 
-    @key_bindings.add('enter', filter=has_selected_completion)
+    @key_bindings.add(u'enter', filter=has_selected_completion)
     def _(event):
         """
         Makes the enter key work as the tab key only when showing the menu.

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -63,7 +63,10 @@ def configure_and_update_options(options):
         if not options.username:
             options.username = input(u'Username (press enter for sa):') or u'sa'
         if not options.password:
-            options.password = getpass.getpass()
+            pw = getpass.getpass()
+            if (pw is not None):
+                pw = pw.replace('\r', '').replace('\n', '')
+            options.password = pw
 
 
 def create_config_dir_for_first_use():

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -417,11 +417,11 @@ class MssqlCli(object):
 
         def get_message():
             prompt = self.get_prompt(self.prompt_format)
-            return [('class:prompt', prompt)]
+            return [(u'class:prompt', prompt)]
 
         def get_continuation(width, line_number, is_soft_wrap):
             continuation = self.multiline_continuation_char * (width - 1) + ' '
-            return [('class:continuation', continuation)]
+            return [(u'class:continuation', continuation)]
 
         get_toolbar_tokens = create_toolbar_tokens_func(self)
 
@@ -446,7 +446,7 @@ class MssqlCli(object):
                             chars='[](){}'),
                         filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
                     # Render \t as 4 spaces instead of "^I"
-                    TabsProcessor(char1=' ', char2=' ')],
+                    TabsProcessor(char1=u' ', char2=u' ')],
                 reserve_space_for_menu=self.min_num_menu_lines,
 
                 # Buffer options.

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -142,20 +142,20 @@ class MssqlCompleter(Completer):
         self.keywords.extend(additional_keywords)
         self.all_completions.update(additional_keywords)
 
-    def extend_schemata(self, schemata):
+    def extend_schemas(self, schemas):
 
-        # schemata is a list of schema names
-        schemata = self.escaped_names(schemata)
+        # schemas is a list of schema names
+        schemas = self.escaped_names(schemas)
         metadata = self.dbmetadata['tables']
-        for schema in schemata:
+        for schema in schemas:
             metadata[schema] = {}
 
         # dbmetadata.values() are the 'tables' and 'functions' dicts
         for metadata in self.dbmetadata.values():
-            for schema in schemata:
+            for schema in schemas:
                 metadata[schema] = {}
 
-        self.all_completions.update(schemata)
+        self.all_completions.update(schemas)
 
     def extend_casing(self, words):
         """ extend casing data

--- a/mssqlcli/mssqlqueries.py
+++ b/mssqlcli/mssqlqueries.py
@@ -1,12 +1,16 @@
+import sys
+import re
+
 def get_schemas():
     """
     Query string to retrieve schema names.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT name
         FROM sys.schemas
         ORDER BY 1'''
+    return normalize(sql)
 
 
 def get_databases():
@@ -14,10 +18,11 @@ def get_databases():
     Query string to retrieve all database names.
     :return: string
     """
-    return '''
+    sql = '''
         Select name
         FROM sys.databases
         ORDER BY 1'''
+    return normalize(sql)
 
 
 def get_table_columns():
@@ -25,7 +30,7 @@ def get_table_columns():
     Query string to retrieve all table columns.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT  isc.table_schema,
                 isc.table_name,
                 isc.column_name,
@@ -49,6 +54,7 @@ def get_table_columns():
             )   AS ist
             ON ist.table_name = isc.table_name AND ist.table_schema = isc.table_schema
             ORDER BY 1, 2'''
+    return normalize(sql)
 
 
 def get_view_columns():
@@ -56,7 +62,7 @@ def get_view_columns():
     Query string to retrieve all view columns.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT  isc.table_schema,
                 isc.table_name,
                 isc.column_name,
@@ -80,6 +86,7 @@ def get_view_columns():
             )   AS ist
             ON ist.table_name = isc.table_name AND ist.table_schema = isc.table_schema
             ORDER BY 1, 2'''
+    return normalize(sql)
 
 
 def get_views():
@@ -87,11 +94,12 @@ def get_views():
     Query string to retrieve all views.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT  table_schema,
                 table_name
         FROM INFORMATION_SCHEMA.VIEWS
         ORDER BY 1, 2'''
+    return normalize(sql)
 
 
 def get_tables():
@@ -99,12 +107,13 @@ def get_tables():
     Query string to retrive all tables.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT  table_schema,
                 table_name
         FROM INFORMATION_SCHEMA.TABLES
         WHERE table_type = 'BASE TABLE'
         ORDER BY 1, 2'''
+    return normalize(sql)
 
 
 def get_user_defined_types():
@@ -112,21 +121,22 @@ def get_user_defined_types():
     Query string to retrieve all user defined types.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT  schemas.name,
                 types.name
         FROM
         (
             SELECT name,
-                   schema_id
+                    schema_id
             FROM sys.types
             WHERE is_user_defined = 1) AS types
         INNER JOIN
         (
             SELECT name,
-                   schema_id
+                    schema_id
             FROM   sys.schemas) AS schemas
         ON types.schema_id = schemas.schema_id'''
+    return normalize(sql)
 
 
 def get_functions():
@@ -134,10 +144,11 @@ def get_functions():
     Query string to retrieve stored procedures and functions.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT specific_schema, specific_name
         FROM INFORMATION_SCHEMA.ROUTINES
         ORDER BY 1, 2'''
+    return normalize(sql)
 
 
 def get_foreignkeys():
@@ -145,7 +156,7 @@ def get_foreignkeys():
     Query string for returning foreign keys.
     :return: string
     """
-    return '''
+    sql = '''
         SELECT
             kcu1.table_schema AS fk_table_schema,
             kcu1.table_name AS fk_table_name,
@@ -164,3 +175,13 @@ def get_foreignkeys():
             AND kcu2.constraint_name = rc.unique_constraint_name
             AND kcu2.ordinal_position = kcu1.ordinal_position
             ORDER BY 3, 4'''
+    return normalize(sql)
+
+
+def normalize(sql):
+    if (sql == '' or sql is None):
+        return sql
+    else:
+        sql = sql.replace('\r', ' ').replace('\n', ' ').strip()
+        sql = re.sub(r' +', ' ', sql)
+        return sql.decode('utf-8') if sys.version_info[0] < 3 else sql

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -200,10 +200,10 @@ class MetaData(object):
         from mssqlcli.mssqlcompleter import MssqlCompleter
         comp = MssqlCompleter(smart_completion=True, settings=settings)
 
-        schemata, tables, tbl_cols, views, view_cols = [], [], [], [], []
+        schemas, tables, tbl_cols, views, view_cols = [], [], [], [], []
 
         for sch, tbls in metadata['tables'].items():
-            schemata.append(sch)
+            schemas.append(sch)
 
             for tbl, cols in tbls.items():
                 tables.append((sch, tbl))
@@ -232,7 +232,7 @@ class MetaData(object):
             ForeignKey(*fk) for fks in metadata['foreignkeys'].values()
             for fk in fks]
 
-        comp.extend_schemata(schemata)
+        comp.extend_schemas(schemas)
         comp.extend_relations(tables, kind='tables')
         comp.extend_relations(views, kind='views')
         comp.extend_columns(tbl_cols, kind='tables')


### PR DESCRIPTION
Some code is broken when running on Python2. 
* `str` type vs `unicode` type
  * string is `unicode` type in Python3 is , but `str` type in Python2
  * In many places, the updated prompt-toolkit has assertion to check if string param is in `unicode`
* User-input string from command prompt (such as db password) contains `\r` character at the end, which leads to invalid credential failure when connecting to db.

