### PR TITLE
Don't overwrite test results and code coverage

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,6 +3,7 @@ from shutil import copyfile
 
 import os
 import sys
+import uuid
 import utility
 
 # Environment variables below allow the build process to use a python interpreter and pip version different
@@ -119,8 +120,9 @@ def unit_test():
     """
     Run all unit tests.
     """
+    runid = str(uuid.uuid1())
     utility.exec_command(
-        'pytest --cov mssqlcli --doctest-modules --junitxml=junit/test-results.xml --cov-report=xml --cov-report=html '
+        'pytest --cov mssqlcli --doctest-modules --junitxml=junit/test-{}-results.xml --cov-report=xml --cov-report=html --cov-append '
         'tests/test_mssqlcliclient.py '
         'tests/test_completion_refresher.py '
         'tests/test_config.py '
@@ -133,7 +135,7 @@ def unit_test():
         'mssqlcli/jsonrpc/tests '
         'mssqlcli/jsonrpc/contracts/tests '
         'tests/test_telemetry.py '
-        'tests/test_special.py',
+        'tests/test_special.py'.format(runid),
         utility.ROOT_DIR,
         continue_on_error=False)
 


### PR DESCRIPTION
Each test results.xml will use a guid in the name, and code coverage will append. This way running tests in tox for 27 won't overwrite the results of 36.