### PR TITLE
Updated mac build instructions for starting venv

### DIFF
--- a/doc/development_guide.md
+++ b/doc/development_guide.md
@@ -94,7 +94,7 @@ python -m virtualenv <workspaceRoot>/env
 ```
 ##### MacOS/Linux
 ```
-. <workspaceRoot>/env/bin/activate
+source <workspaceRoot>/env/bin/activate
 ```
 
 ### (To deactivate the Virtual Environment)


### PR DESCRIPTION
On Mac, 'source' needs to precede the file path to call the 'activate' script.