### PR TITLE
Rolled back to scripts from entry_points in setup.py

### DIFF
--- a/mssql-cli
+++ b/mssql-cli
@@ -13,4 +13,4 @@ if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi
 
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 
-( command -v python3 && python3 -m mssqlcli.main "$@" ) || python -m mssqlcli.main "$@"
+python -m mssqlcli.main "$@"

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ setup(
     long_description=open('README.rst', encoding='utf-8').read(),
     install_requires=install_requirements,
     include_package_data=True,
-    entry_points = {"console_scripts": [
-        "mssql-cli.bat = mssqlcli.main:main",
-        "mssql-cli = mssqlcli.main:main"
-    ]},
+    scripts=[	   
+        'mssql-cli.bat',
+        'mssql-cli'
+    ],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Rolled back to scripts from entry_points in setup.py.
`entry_points` config makes start process trigger `mssqlcli.main` directly, and we lose a chance to set `PYTHONIOENCODING` information. 
```
entry_points = {
    "console_scripts": [
        "mssql-cli.bat = mssqlcli.main:main",
        "mssql-cli = mssqlcli.main:main"
    ]
},
```
For launching mssql-cli `mssql-cli` script, it is more appropriate to follow the way of launching azure-cli in `az` script.
```
python -m azure.cli "$@"
```