### PR TITLE
Fix folder name for config

### DIFF
--- a/doc/troubleshooting_guide.md
+++ b/doc/troubleshooting_guide.md
@@ -60,7 +60,7 @@ To fix this issue, uncomment
 the pager option in your config file located here
 * Unix/Linux
 ```
-    ~/.config/mssql-cli/config
+    ~/.config/mssqlcli/config
     
     # Default pager.
     # By default 'PAGER' environment variable is used
@@ -68,7 +68,7 @@ the pager option in your config file located here
 ```
 * In Windows: 
 ```
-    %USERPROFILE%\AppData\Local\dbcli\mssql-cli\config
+    %USERPROFILE%\AppData\Local\dbcli\mssqlcli\config
     
     # Default pager.
     # By default 'PAGER' environment variable is used


### PR DESCRIPTION
Folder name for config is mssqlcli, not mssql-cli. See:
https://github.com/dbcli/mssql-cli/blob/3a71bfe7e438cc905283797304dc09ddac5ce397/mssqlcli/config.py#L9