### PR TITLE
Fixed incorrect pythonpath reference

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,7 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceRoot}/mssqlcli/main.py",
-            "env": {
-                "PYTHONPATH":"${workspaceRoot};${env:PYTHONPATH}"
-            },
+            "pythonPath": "${config:python.pythonPath}",
             "console": "integratedTerminal",
         },
         {
@@ -16,9 +14,7 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceRoot}/mssqlcli/main.py",
-            "env": {
-                "PYTHONPATH":"${workspaceRoot};${env:PYTHONPATH}"
-            },
+            "pythonPath": "${config:python.pythonPath}",
             "console": "externalTerminal",
         }
     ]


### PR DESCRIPTION
The setting for PYTHONPATH was incorrect in launch.json, which led to unfound modules in debug mode. This fix enables debug mode in VS Code to work again.