### PR TITLE
refactored client testing

### DIFF
--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -31,7 +31,7 @@ class MssqlCliClient:
         yield cl
         shutdown(cl)
 
-class TestMssqlCliClientConnection:
+class TestMssqlCliClientConnection(MssqlCliClient):
     """
         Tests for mssqlcliclient.py and sqltoolsclient.py.
     """
@@ -92,18 +92,16 @@ class TestMssqlCliClientConnection:
             shutdown(client)
 
     @staticmethod
-    def test_json_writer_extra_params():
+    def test_json_writer_extra_params(client):
         """
             Verify JSON RPC accepts extra paramaters.
         """
         try:
-            client = create_mssql_cli_client()
             extra_params = client.extra_params
             json_writer = JsonRpcWriter(io.BytesIO())
             json_writer.send_request(u'test/method', extra_params, id=1)
         finally:
             json_writer.close()
-            shutdown(client)
 
     @staticmethod
     def test_mssqlcliclient_reset_connection():

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -169,7 +169,6 @@ class TestMssqlCliClientQuery(MssqlCliClient):
             assert (schematest, tabletest1, 'a', 'int', 'NULL') in set(client.get_table_columns())
             assert ('dbo', viewtest, 'a', 'int', 'NULL') in set(client.get_view_columns())
             assert schematest in client.get_schemas()
-
         finally:
             drop_entities(client)
 
@@ -188,13 +187,15 @@ class TestMssqlCliClientQuery(MssqlCliClient):
         exec_stored_proc = u"EXEC sp_mssqlcli_multiple_results"
         del_stored_proc = u"DROP PROCEDURE sp_mssqlcli_multiple_results"
 
-        list(client.execute_query(create_stored_proc))
-        row_counts = []
-        for rows, _, _, _, _ in client.execute_query(exec_stored_proc):
-            row_counts.append(len(rows))
-        assert row_counts[0] == 2
-        assert row_counts[1] == 3
-        list(client.execute_query(del_stored_proc))
+        try:
+            list(client.execute_query(create_stored_proc))
+            row_counts = []
+            for rows, _, _, _, _ in client.execute_query(exec_stored_proc):
+                row_counts.append(len(rows))
+            assert row_counts[0] == 2
+            assert row_counts[1] == 3
+        finally:
+            list(client.execute_query(del_stored_proc))
 
 
 class TestMssqlCliClientMultipleStatement(MssqlCliClient):

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -14,14 +14,9 @@ from mssqltestutils import (
 )
 
 
-# TODO: fix comment
-
-# All tests apart from test_mssqlcliclient_request_response require a live connection to an
-# AdventureWorks2014 database with a hardcoded test server.
-# Make modifications to mssqlutils.create_mssql_cli_client() to use a different server and database.
 # Please Note: These tests cannot be run offline.
 
-class MssqlCliClient:
+class MssqlCliClient:   # pylint: disable=too-few-public-methods
     """ Creates client fixture to be used for tests. """
 
     @staticmethod
@@ -200,10 +195,11 @@ class TestMssqlCliClientQuery(MssqlCliClient):
 
 class TestMssqlCliClientMultipleStatement(MssqlCliClient):
     test_data = [
+        # random strings used to test for errors with non-existing tables
         (u"select 'Morning' as [Name] UNION ALL select 'Evening'; " +
          u"select 1;", [2, 1]),
-        (u"select 1; select 'foo' from teapot;", [1, 0]),
-        (u"select 'foo' from teapot; select 2;", [0, 1])
+        (u"select 1; select 'foo' from %s;" % random_str(), [1, 0]),
+        (u"select 'foo' from %s; select 2;" % random_str(), [0, 1])
     ]
 
     @staticmethod


### PR DESCRIPTION
Fixes #279.

This PR refactors our testing of the mssqlcli client. Changes include:
* Introduction of pytest fixtures for safe creation/teardown and readability
* Organization of tests into separate classes to isolate write workloads/improved readability
* Use of try/finally blocks for safe teardown

The diff is a huge mess so I'll leave comments throughout to explain changes.