### PR TITLE
Show local variables in traceback for tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -127,7 +127,7 @@ def unit_test():
     runid = str(uuid.uuid1())
     python_version = platform.python_version()
     utility.exec_command(
-        'pytest --cov mssqlcli --doctest-modules --junitxml=junit/test-{}-results.xml \
+        'pytest -l --cov mssqlcli --doctest-modules --junitxml=junit/test-{}-results.xml \
             --cov-report=xml --cov-report=html --cov-append '
         '-o junit_suite_name=pytest-{} '
         'tests/test_mssqlcliclient.py '


### PR DESCRIPTION
Fixes #352.

Occasionally we'll see test failures that lack enough local context for effective debugging. By including the `-l` flag with our testing, our traceback will include information about all variables used in the test method.

This is especially helpful for flaky tests which may be difficult to repro.