### PR TITLE
Added retry logic for create db

### DIFF
--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import warnings
 from argparse import Namespace
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
@@ -79,28 +80,22 @@ def create_test_db():
     test_db_name = u'mssqlcli_testdb_{0}_{1}'.format(
         local_machine_name, random_str())
     query_db_create = u"CREATE DATABASE {0};".format(test_db_name)
-    rows, columns, status, statement, is_error = None, None, None, None, None
     count = 0
 
     # retry logic in case db create fails
     while count < 5:
-        for _, _, _, _, is_create_error in client.execute_query(query_db_create):
+        for _, _, status, _, is_create_error in client.execute_query(query_db_create):
             if not is_create_error:
                 shutdown(client)
                 return test_db_name
+            # log warning to console
+            warnings.warn('Test DB create failed with error: {0}'.format(status))
         count += 1
     shutdown(client)
 
     # cleanup db just in case, then raise exception
     clean_up_test_db(test_db_name)
-    raise AssertionError(
-        ("DB creation failed:\n"
-         "rows:\t{0}\n"
-         "columns:\t{1}\n"
-         "status:\t{2}\n"
-         "statement:\t{3}\n"
-         "is_error:\t{4}").format(rows, columns, status, statement, is_error)
-    )
+    raise AssertionError("DB creation failed.")
 
 
 def clean_up_test_db(test_db_name):


### PR DESCRIPTION
Fixes #280.

I added retry logic to the create db method used for our tests. In the past this method would occasionally fail due to network issues, so I'm hoping that the retry logic will fix this issue.