### PR TITLE
JSON RPC client testing improvements

### DIFF
--- a/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
+++ b/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
@@ -254,7 +254,7 @@ class JsonRpcClientTests(unittest.TestCase):
         self.assertFalse(test_client.request_thread.is_alive())
         self.assertFalse(test_client.response_thread.is_alive())
 
-    @unittest.skip("Test functionality is broken.")
+    @unittest.skip("Test functionality is broken: ValueError is never thrown.")
     def test_stream_closed_during_process(self):
         """
             Verify request stream closed, exception returned and request thread died.

--- a/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
+++ b/mssqlcli/jsonrpc/tests/test_jsonrpcclient.py
@@ -207,7 +207,7 @@ class JsonRpcClientTests(unittest.TestCase):
             test_client.shutdown()
             self.assertFalse(test_client.request_thread.is_alive())
         else:
-            raise AssertionError("LookupError exception not caught when it should've been.")
+            raise AssertionError("LookupError should have been thrown.")
         finally:
             test_client.shutdown()
 
@@ -229,7 +229,9 @@ class JsonRpcClientTests(unittest.TestCase):
             # Verify the background thread communicated the exception.
             self.assertEqual(
                 str(exception), u'I/O operation on closed file.')
-
+        else:
+            raise AssertionError("ValueError should have been thrown.")
+        finally:
             test_client.shutdown()
 
     @unittest.skip("Disabling until scenario is valid")
@@ -252,6 +254,7 @@ class JsonRpcClientTests(unittest.TestCase):
         self.assertFalse(test_client.request_thread.is_alive())
         self.assertFalse(test_client.response_thread.is_alive())
 
+    @unittest.skip("Test functionality is broken.")
     def test_stream_closed_during_process(self):
         """
             Verify request stream closed, exception returned and request thread died.
@@ -277,6 +280,9 @@ class JsonRpcClientTests(unittest.TestCase):
                 str(exception), u'I/O operation on closed file.')
             # Verify response thread is dead.
             self.assertFalse(test_client.request_thread.is_alive())
+        else:
+            raise AssertionError("ValueError should have been thrown.")
+        finally:
             test_client.shutdown()
 
     def test_get_response_with_id(self):


### PR DESCRIPTION
Happy Thanksgiving!

This PR improves our testing with JSON RPC client. Changes specifically address feedback from the Weekly Tech Review.

Changes:
* Addresses a hopeful fix for the flaky test that sometimes failed to shut down a thread.
* Raises assertion errors when exceptions should've been caught but didn't.

In thanks to these changes, I discovered that one of our tests fails to catch an exception when it should've. I raised an issue at #371 and have marked that specific test method to skip on runtime.

Tag: #281