### PR TITLE
Multi-line statements now execute on 'GO'

### DIFF
--- a/build.py
+++ b/build.py
@@ -173,6 +173,7 @@ def get_active_test_filepaths():
         'tests/test_config.py '
         'tests/test_naive_completion.py '
         'tests/test_main.py '
+        'tests/test_multiline.py '
         'tests/test_fuzzy_completion.py '
         'tests/test_rowlimit.py '
         'tests/test_sqlcompletion.py '

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -37,10 +37,13 @@ def _is_complete(sql):
         # check that 'go' is only token on newline
         lines = sql.split('\n')
         lastline = lines[len(lines) - 1].lower().strip()
-        is_valid_go_on_lastline = 'go' == lastline
+        is_valid_go_on_lastline = lastline == 'go'
 
         # check that 'go' is on last line, not in open quotes, and there's no open
-        # comment with closed comments and quotes removed
+        # comment with closed comments and quotes removed.
+        # NOTE: this method fails when GO follows a closing '*/' block comment on the same line,
+        # we've taken a dependency with sqlparse
+        # (https://github.com/andialbrecht/sqlparse/issues/484)
         return not is_open_quote(sql) and not is_open_comment and is_valid_go_on_lastline
 
     return False

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -24,7 +24,9 @@ def _is_complete(sql):
     # A complete command is an sql statement that ends with a 'GO', unless
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
-    return sql.lower().endswith('go') and not is_open_quote(sql)
+    if sql is not "":
+        tokens = sql.split()
+        return tokens[len(tokens) - 1].lower() == 'go' and not is_open_quote(sql)
 
 
 def _multiline_exception(text):

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -24,17 +24,19 @@ def _is_complete(sql):
     # A complete command is an sql statement that ends with a 'GO', unless
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
-    if sql is not "":
+    if sql != "":
         tokens = sql.split('\n')
         lastline = tokens[len(tokens) - 1]
-        
+
         # remove commented code in last line to ensure we have a valid 'go'
         # to end the multiline query
-        comments = re.findall('\/\*.*?\*\/|--.*?\n', lastline)
+        comments = re.findall(r'\/\*.*?\*\/|--.*', lastline)
         for comment in comments:
             lastline = lastline.replace(comment, '')
 
         return lastline.lower().strip() == 'go' and not is_open_quote(sql)
+
+    return False
 
 
 def _multiline_exception(text):

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -21,10 +21,10 @@ def mssql_is_multiline(mssql_cli):
 
 
 def _is_complete(sql):
-    # A complete command is an sql statement that ends with a semicolon, unless
+    # A complete command is an sql statement that ends with a 'GO', unless
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
-    return sql.endswith(';') and not is_open_quote(sql)
+    return sql.lower().endswith('go') and not is_open_quote(sql)
 
 
 def _multiline_exception(text):

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-
+import re
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.application import get_app
@@ -25,8 +25,16 @@ def _is_complete(sql):
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
     if sql is not "":
-        tokens = sql.split()
-        return tokens[len(tokens) - 1].lower() == 'go' and not is_open_quote(sql)
+        tokens = sql.split('\n')
+        lastline = tokens[len(tokens) - 1]
+        
+        # remove commented code in last line to ensure we have a valid 'go'
+        # to end the multiline query
+        comments = re.findall('\/\*.*?\*\/|--.*?\n', lastline)
+        for comment in comments:
+            lastline = lastline.replace(comment, '')
+
+        return lastline.lower().strip() == 'go' and not is_open_quote(sql)
 
 
 def _multiline_exception(text):

--- a/mssqlcli/mssqlbuffer.py
+++ b/mssqlcli/mssqlbuffer.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import re
+import sqlparse
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.application import get_app
@@ -25,14 +25,11 @@ def _is_complete(sql):
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
     if sql != "":
+        # remove comments
+        sql = sqlparse.format(sql, strip_comments=True)
+
         tokens = sql.split('\n')
         lastline = tokens[len(tokens) - 1]
-
-        # remove commented code in last line to ensure we have a valid 'go'
-        # to end the multiline query
-        comments = re.findall(r'\/\*.*?\*\/|--.*', lastline)
-        for comment in comments:
-            lastline = lastline.replace(comment, '')
 
         return lastline.lower().strip() == 'go' and not is_open_quote(sql)
 

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -230,7 +230,7 @@ class MssqlCliClient:
         query_has_exception = query_response.exception_message
         query_has_error_messages = query_messages[0].is_error if query_messages else False
         query_has_batch_error = query_response.batch_summaries[0].has_error \
-            if query_response.batch_summaries else False
+            if hasattr(query_response, 'batch_summaries') else False
 
         query_failed = query_has_exception or query_has_batch_error or query_has_error_messages
 

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -230,7 +230,7 @@ class MssqlCliClient:
         query_has_exception = query_response.exception_message
         query_has_error_messages = query_messages[0].is_error if query_messages else False
         query_has_batch_error = query_response.batch_summaries[0].has_error \
-            if hasattr(query_response, 'batch_summaries') else False
+            if query_response.batch_summaries else False
 
         query_failed = query_has_exception or query_has_batch_error or query_has_error_messages
 
@@ -277,7 +277,8 @@ class MssqlCliClient:
 
     @staticmethod
     def _no_results_found_in(query_response):
-        return not query_response.batch_summaries[0].result_set_summaries
+        return not query_response.batch_summaries \
+               or not query_response.batch_summaries[0].result_set_summaries
 
     @staticmethod
     def _no_rows_found_in(query_response):

--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -230,7 +230,8 @@ class MssqlCliClient:
         query_has_exception = query_response.exception_message
         query_has_error_messages = query_messages[0].is_error if query_messages else False
         query_has_batch_error = query_response.batch_summaries[0].has_error \
-            if hasattr(query_response, 'batch_summaries') else False
+            if hasattr(query_response, 'batch_summaries') \
+                and len(query_response.batch_summaries) > 0 else False
 
         query_failed = query_has_exception or query_has_batch_error or query_has_error_messages
 

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -10,13 +10,13 @@ smart_completion = True
 wider_completion_menu = False
 
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
-# this is set to True, then the end of the statements must have a semi-colon.
+# this is set to True, then the end of the statements must have 'GO'.
 # If this is set to False then sql statements can't be split into multiple
 # lines. End of line (return) is considered as the end of the statement.
 multi_line = False
 
 # If multi_line_mode is set to "tsql", in multi-line mode, [Enter] will execute
-# the current input if the input ends in a semicolon.
+# the current input if the input ends in 'GO'.
 # If multi_line_mode is set to "safe", in multi-line mode, [Enter] will always
 # insert a newline, and [Esc] [Enter] or [Alt]-[Enter] must be used to execute
 # a command.

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -149,7 +149,7 @@ class MssqlCompleter(Completer):
         return [cls.escape_name(name) for name in names]
 
     def extend_database_names(self, databases):
-        databases = self.escaped_names(databases)
+        databases = MssqlCompleter.escaped_names(databases)
         self.databases.extend(databases)
 
     def extend_keywords(self, additional_keywords):
@@ -159,7 +159,7 @@ class MssqlCompleter(Completer):
     def extend_schemas(self, schemas):
 
         # schemas is a list of schema names
-        schemas = self.escaped_names(schemas)
+        schemas = MssqlCompleter.escaped_names(schemas)
         metadata = self.dbmetadata['tables']
         for schema in schemas:
             metadata[schema] = {}
@@ -189,7 +189,7 @@ class MssqlCompleter(Completer):
 
         """
 
-        data = [self.escaped_names(d) for d in data]
+        data = [MssqlCompleter.escaped_names(d) for d in data]
 
         # dbmetadata['tables']['schema_name']['table_name'] should be an
         # OrderedDict {column_name:ColumnMetaData}.
@@ -214,7 +214,7 @@ class MssqlCompleter(Completer):
         """
         metadata = self.dbmetadata[kind]
         for schema, relname, colname, datatype, default in column_data:
-            (schema, relname, colname) = self.escaped_names(
+            (schema, relname, colname) = MssqlCompleter.escaped_names(
                 [schema, relname, colname])
             column = ColumnMetadata(
                 name=colname,
@@ -234,7 +234,7 @@ class MssqlCompleter(Completer):
         metadata = self.dbmetadata['functions']
 
         for f in func_data:
-            schema, func = self.escaped_names([f.schema_name, f.func_name])
+            schema, func = MssqlCompleter.escaped_names([f.schema_name, f.func_name])
 
             if func in metadata[schema]:
                 metadata[schema][func].append(f)
@@ -271,7 +271,7 @@ class MssqlCompleter(Completer):
         meta = self.dbmetadata['tables']
 
         for fk in fk_data:
-            e = self.escaped_names
+            e = MssqlCompleter.escaped_names
             parentschema, childschema = e([fk.parentschema, fk.childschema])
             parenttable, childtable = e([fk.parenttable, fk.childtable])
             childcol, parcol = e([fk.childcolumn, fk.parentcolumn])
@@ -290,7 +290,7 @@ class MssqlCompleter(Completer):
         meta = self.dbmetadata['datatypes']
 
         for t in type_data:
-            schema, type_name = self.escaped_names(t)
+            schema, type_name = MssqlCompleter.escaped_names(t)
             meta[schema][type_name] = None
             self.all_completions.add(type_name)
 
@@ -303,7 +303,7 @@ class MssqlCompleter(Completer):
             self.prioritizer.update(text)
 
     def set_search_path(self, search_path):
-        self.search_path = self.escaped_names(search_path)
+        self.search_path = MssqlCompleter.escaped_names(search_path)
 
     def reset_completions(self):
         self.databases = []
@@ -416,7 +416,7 @@ class MssqlCompleter(Completer):
                 # We also use the unescape_name to make sure quoted names have
                 # the same priority as unquoted names.
                 lexical_priority = (tuple(0 if c in(' _') else -ord(c) \
-                                    for c in self.unescape_name(item.lower())) +
+                                    for c in MssqlCompleter.unescape_name(item.lower())) +
                                     (1,) + tuple(c for c in item))
 
                 item = self.case(item)
@@ -557,7 +557,7 @@ class MssqlCompleter(Completer):
         tbl = self.case(tbl)
         tbls = set(normalize_ref(t.ref) for t in tbls)
         if self.generate_aliases:
-            tbl = generate_alias(self.unescape_name(tbl))
+            tbl = generate_alias(MssqlCompleter.unescape_name(tbl))
         if normalize_ref(tbl) not in tbls:
             return tbl
         if tbl[0] == '"':
@@ -699,7 +699,7 @@ class MssqlCompleter(Completer):
     def get_schema_matches(self, suggestion, word_before_cursor):
         schema_names = self.dbmetadata['tables'].keys()
         if suggestion.quoted:
-            schema_names = [self.escape_schema(s) for s in schema_names]
+            schema_names = [MssqlCompleter.escape_schema(s) for s in schema_names]
 
         return self.find_matches(
             word_before_cursor, schema_names, meta='schema')
@@ -908,8 +908,8 @@ class MssqlCompleter(Completer):
                 continue
             schemas = [tbl.schema] if tbl.schema else self.search_path
             for schema in schemas:
-                relname = self.escape_name(tbl.name)
-                schema = self.escape_name(schema)
+                relname = MssqlCompleter.escape_name(tbl.name)
+                schema = MssqlCompleter.escape_name(schema)
                 if tbl.is_function:
                     # Return column names from a set-returning function
                     # Get an array of FunctionMetadata objects
@@ -936,7 +936,7 @@ class MssqlCompleter(Completer):
         """
         metadata = self.dbmetadata[obj_typ]
         if schema:
-            schema = self.escape_name(schema)
+            schema = MssqlCompleter.escape_name(schema)
             return [schema] if schema in metadata else []
         return self.search_path if self.search_path_filter else metadata.keys()
 

--- a/mssqlcli/mssqlcompleter.py
+++ b/mssqlcli/mssqlcompleter.py
@@ -149,7 +149,7 @@ class MssqlCompleter(Completer):
         return [cls.escape_name(name) for name in names]
 
     def extend_database_names(self, databases):
-        databases = MssqlCompleter.escaped_names(databases)
+        databases = self.escaped_names(databases)
         self.databases.extend(databases)
 
     def extend_keywords(self, additional_keywords):
@@ -159,7 +159,7 @@ class MssqlCompleter(Completer):
     def extend_schemas(self, schemas):
 
         # schemas is a list of schema names
-        schemas = MssqlCompleter.escaped_names(schemas)
+        schemas = self.escaped_names(schemas)
         metadata = self.dbmetadata['tables']
         for schema in schemas:
             metadata[schema] = {}
@@ -189,7 +189,7 @@ class MssqlCompleter(Completer):
 
         """
 
-        data = [MssqlCompleter.escaped_names(d) for d in data]
+        data = [self.escaped_names(d) for d in data]
 
         # dbmetadata['tables']['schema_name']['table_name'] should be an
         # OrderedDict {column_name:ColumnMetaData}.
@@ -214,7 +214,7 @@ class MssqlCompleter(Completer):
         """
         metadata = self.dbmetadata[kind]
         for schema, relname, colname, datatype, default in column_data:
-            (schema, relname, colname) = MssqlCompleter.escaped_names(
+            (schema, relname, colname) = self.escaped_names(
                 [schema, relname, colname])
             column = ColumnMetadata(
                 name=colname,
@@ -234,7 +234,7 @@ class MssqlCompleter(Completer):
         metadata = self.dbmetadata['functions']
 
         for f in func_data:
-            schema, func = MssqlCompleter.escaped_names([f.schema_name, f.func_name])
+            schema, func = self.escaped_names([f.schema_name, f.func_name])
 
             if func in metadata[schema]:
                 metadata[schema][func].append(f)
@@ -271,7 +271,7 @@ class MssqlCompleter(Completer):
         meta = self.dbmetadata['tables']
 
         for fk in fk_data:
-            e = MssqlCompleter.escaped_names
+            e = self.escaped_names
             parentschema, childschema = e([fk.parentschema, fk.childschema])
             parenttable, childtable = e([fk.parenttable, fk.childtable])
             childcol, parcol = e([fk.childcolumn, fk.parentcolumn])
@@ -290,7 +290,7 @@ class MssqlCompleter(Completer):
         meta = self.dbmetadata['datatypes']
 
         for t in type_data:
-            schema, type_name = MssqlCompleter.escaped_names(t)
+            schema, type_name = self.escaped_names(t)
             meta[schema][type_name] = None
             self.all_completions.add(type_name)
 
@@ -303,7 +303,7 @@ class MssqlCompleter(Completer):
             self.prioritizer.update(text)
 
     def set_search_path(self, search_path):
-        self.search_path = MssqlCompleter.escaped_names(search_path)
+        self.search_path = self.escaped_names(search_path)
 
     def reset_completions(self):
         self.databases = []
@@ -416,7 +416,7 @@ class MssqlCompleter(Completer):
                 # We also use the unescape_name to make sure quoted names have
                 # the same priority as unquoted names.
                 lexical_priority = (tuple(0 if c in(' _') else -ord(c) \
-                                    for c in MssqlCompleter.unescape_name(item.lower())) +
+                                    for c in self.unescape_name(item.lower())) +
                                     (1,) + tuple(c for c in item))
 
                 item = self.case(item)
@@ -557,7 +557,7 @@ class MssqlCompleter(Completer):
         tbl = self.case(tbl)
         tbls = set(normalize_ref(t.ref) for t in tbls)
         if self.generate_aliases:
-            tbl = generate_alias(MssqlCompleter.unescape_name(tbl))
+            tbl = generate_alias(self.unescape_name(tbl))
         if normalize_ref(tbl) not in tbls:
             return tbl
         if tbl[0] == '"':
@@ -699,7 +699,7 @@ class MssqlCompleter(Completer):
     def get_schema_matches(self, suggestion, word_before_cursor):
         schema_names = self.dbmetadata['tables'].keys()
         if suggestion.quoted:
-            schema_names = [MssqlCompleter.escape_schema(s) for s in schema_names]
+            schema_names = [self.escape_schema(s) for s in schema_names]
 
         return self.find_matches(
             word_before_cursor, schema_names, meta='schema')
@@ -908,8 +908,8 @@ class MssqlCompleter(Completer):
                 continue
             schemas = [tbl.schema] if tbl.schema else self.search_path
             for schema in schemas:
-                relname = MssqlCompleter.escape_name(tbl.name)
-                schema = MssqlCompleter.escape_name(schema)
+                relname = self.escape_name(tbl.name)
+                schema = self.escape_name(schema)
                 if tbl.is_function:
                     # Return column names from a set-returning function
                     # Get an array of FunctionMetadata objects
@@ -936,7 +936,7 @@ class MssqlCompleter(Completer):
         """
         metadata = self.dbmetadata[obj_typ]
         if schema:
-            schema = MssqlCompleter.escape_name(schema)
+            schema = self.escape_name(schema)
             return [schema] if schema in metadata else []
         return self.search_path if self.search_path_filter else metadata.keys()
 

--- a/mssqlcli/mssqltoolbar.py
+++ b/mssqlcli/mssqltoolbar.py
@@ -39,7 +39,7 @@ def create_toolbar_tokens_func(mssql_cli):
             if mssql_cli.multiline_mode == 'safe':
                 result.append((token, ' ([Esc] [Enter] to execute]) '))
             else:
-                result.append((token, ' (Semi-colon [;] will end the line) '))
+                result.append((token, ' ([GO] statement will end the line) '))
 
         if mssql_cli.vi_mode:
             result.append(

--- a/mssqlcli/packages/parseutils/utils.py
+++ b/mssqlcli/packages/parseutils/utils.py
@@ -113,7 +113,7 @@ def is_open_quote(sql):
 
 def _parsed_is_open_quote(parsed):
     # Look for unmatched single quotes, or unmatched dollar sign quotes
-    return any(tok.match(Token.Error, ("'", "$")) for tok in parsed.flatten())
+    return any(tok.match(Token.Error, ("'", '"', "$")) for tok in parsed.flatten())
 
 
 def parse_partial_identifier(word):

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -9,10 +9,13 @@ class TestMssqlCliMultiline:
         ('select 1 /* open comment!\ngo', False),
         ('select 1\ngo -- another comment', True),
         ('select 1; select 2, "open quote: go', False),
+        ('select 1\n"go"', False),
         ('select 1; GO', False),
+        ('SELECT 4;\nGO', True),
         ('select 1\n select 2;\ngo', True),
         ('select 1;', False),
-        ('select 1 go', False)
+        ('select 1 go', False),
+        ('select 1\ngo go go', False)
         # tests below to be enabled when sqlparse supports retaining newlines
         # when stripping comments:
         # ('select 3 /* another open comment\n*/   GO', True),

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -4,13 +4,20 @@ from mssqlcli.mssqlbuffer import _is_complete
 
 class TestMssqlCliMultiline:
     testdata = [
+        (None, False),
+        ('', False),
         ('select 1 /* open comment!\ngo', False),
         ('select 1\ngo -- another comment', True),
         ('select 1; select 2, "open quote: go', False),
-        ('select 1; go', False),
+        ('select 1; GO', False),
         ('select 1\n select 2;\ngo', True),
         ('select 1;', False),
-        ('select 3 /* another open comment\n*/   go', True)
+        ('select 1 go', False)
+        # tests below to be enabled when sqlparse supports retaining newlines
+        # when stripping comments:
+        # ('select 3 /* another open comment\n*/   GO', True),
+        # ('select 1\n*/go', False),
+        # ('select 1 /*\nmultiple lines!\n*/go', True)
     ]
 
     @staticmethod

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -15,9 +15,12 @@ class TestMssqlCliMultiline:
         ('select 1\n select 2;\ngo', True),
         ('select 1;', False),
         ('select 1 go', False),
-        ('select 1\ngo go go', False)
+        ('select 1\ngo go go', False),
+        ('GO select 1', False),
+        ('GO', True)
         # tests below to be enabled when sqlparse supports retaining newlines
-        # when stripping comments (tracking here: https://github.com/andialbrecht/sqlparse/issues/484):
+        # when stripping comments (tracking here:
+        # https://github.com/andialbrecht/sqlparse/issues/484):
         # ('select 3 /* another open comment\n*/   GO', True),
         # ('select 1\n*/go', False),
         # ('select 1 /*\nmultiple lines!\n*/go', True)
@@ -26,4 +29,9 @@ class TestMssqlCliMultiline:
     @staticmethod
     @pytest.mark.parametrize("query_str, is_complete", testdata)
     def test_multiline_completeness(query_str, is_complete):
+        """
+        Tests the _is_complete helper method, which parses a T-SQL multiline
+        statement on each newline and determines whether the script should
+        execute.
+        """
         assert _is_complete(query_str) == is_complete

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -17,7 +17,7 @@ class TestMssqlCliMultiline:
         ('select 1 go', False),
         ('select 1\ngo go go', False)
         # tests below to be enabled when sqlparse supports retaining newlines
-        # when stripping comments:
+        # when stripping comments (tracking here: https://github.com/andialbrecht/sqlparse/issues/484):
         # ('select 3 /* another open comment\n*/   GO', True),
         # ('select 1\n*/go', False),
         # ('select 1 /*\nmultiple lines!\n*/go', True)

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -1,0 +1,17 @@
+import pytest
+from mssqlcli.mssqlbuffer import _is_complete
+
+
+class TestMssqlCliMultiline:
+    testdata = [
+        ('select 1 /* open comment!\ngo', False),
+        ('select 1\ngo -- another comment', True),
+        ('select 1; select 2, "open quote: go', False),
+        ('select 1\n select 2;\ngo', True),
+        ('select 1;', False)
+    ]
+
+    @staticmethod
+    @pytest.mark.parametrize("query_str, is_complete", testdata)
+    def test_multiline_completeness(query_str, is_complete):
+        assert _is_complete(query_str) == is_complete

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -7,8 +7,10 @@ class TestMssqlCliMultiline:
         ('select 1 /* open comment!\ngo', False),
         ('select 1\ngo -- another comment', True),
         ('select 1; select 2, "open quote: go', False),
+        ('select 1; go', False),
         ('select 1\n select 2;\ngo', True),
-        ('select 1;', False)
+        ('select 1;', False),
+        ('select 3 /* another open comment\n*/   go', True)
     ]
 
     @staticmethod


### PR DESCRIPTION
Closes #175.

Changes include:
* Multi-line queries only execute when `GO` is the only token on a newline
* Updated all code references for using `GO` instead of semicolon
* Bug fix that caused some multi-line statements to crash when batching multiple queries
* Tests for valid multi-line completion

**Disclaimer:** I have not accounted for an edge cause where a block comment may end on the same line as `GO`. For example, the following statement should execute but does not for us:
```
select 1 /* hey some comment
and the comment keeps going */ go
```

I have decided to forgo this edge case in favor of waiting for our dependency, sqlparse, to fix a bug that strips newlines from a method I'm using to strip comments (tracked [here](https://github.com/andialbrecht/sqlparse/issues/484)). I'm open to a discussion on this @udeeshagautam @chlafreniere.