### PR TITLE
Skip telemetry test if opt out policy set to true

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -25,6 +25,8 @@ class TelemetryTests(unittest.TestCase):
         import mssqlcli.telemetry as telemetry      # pylint: disable=import-outside-toplevel
         return telemetry
 
+    @unittest.skipUnless(os.environ['MSSQL_CLI_TELEMETRY_OPTOUT'].lower() != 'true',
+                         "Only works when telemetry opt-out not set to true.")
     def test_telemetry_data_points(self):
         test_telemetry_client = self.build_telemetry_client()
         test_telemetry_client.start()


### PR DESCRIPTION
Until recently, our test pipelines in Azure were logging telemetry. We set our opt-out policy to True in an effort to log accurate data to our analytics, but our tests started to fail due to a unit test that checks for a non-empty payload against the telemetry client. When telemetry is turned off, the payload is empty, thus failing the test.

A better solution is needed that properly tests a working telemetry client without logging data or impacting customer privacy. We should revisit this at a later time.