### PR TITLE
Disabled sdist create and publish

### DIFF
--- a/build.py
+++ b/build.py
@@ -80,12 +80,6 @@ def build():
                              utility.ROOT_DIR,
                              continue_on_error=False)
 
-        # generate sdist--only run on macOS to eliminate redundant copies when published to Azure
-        # NOTE: macOS was arbitrarily chosen as the single OS
-        if sys.platform == 'darwin':
-            utility.exec_command('%s setup.py check -r -s sdist --formats=gztar' % PYTHON,
-                                 utility.ROOT_DIR, continue_on_error=False)
-
     # Copy back the SqlToolsService binaries for this platform.
     clean_and_copy_sqltoolsservice(utility.get_current_platform())
     copy_and_rename_wheels()

--- a/release.py
+++ b/release.py
@@ -80,8 +80,7 @@ def download_official_wheels():
         'mssql_cli-{}-py2.py3-none-macosx_10_11_intel.whl'.format(latest_version),
         'mssql_cli-{}-py2.py3-none-manylinux1_x86_64.whl'.format(latest_version),
         'mssql_cli-{}-py2.py3-none-win_amd64.whl'.format(latest_version),
-        'mssql_cli-{}-py2.py3-none-win32.whl'.format(latest_version),
-        'mssql_cli-{}.tar.gz'.format(latest_version)
+        'mssql_cli-{}-py2.py3-none-win32.whl'.format(latest_version)
     ]
 
     blob_service = BlockBlobService(connection_string=AZURE_STORAGE_CONNECTION_STRING)


### PR DESCRIPTION
Fixes #412.

Our current implementation of sdist fails on platforms other than macOS. We're disabling the creation and publishing of sdist's until it is fixed.

Future work tracked at #414.