### PR TITLE
Build and release .deb package

### DIFF
--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -57,6 +57,9 @@ make install
 export CUSTOM_PYTHON=$source_dir/python_env/bin/python3
 export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
+# Download dependencies needed to run build stage
+$source_dir/python_env/bin/python3 -m pip install -r $source_dir/requirements-dev.txt
+
 # Build mssql-cli wheel from source.
 cd $source_dir
 $source_dir/python_env/bin/python3 $source_dir/build.py build

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -22,7 +22,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 debian_directory_creator=$script_dir/dir_creator.sh
 
 # Install dependencies for the build
-sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools
+sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools python3-all
 # Download, Extract, Patch, Build CLI
 tmp_pkg_dir=$(mktemp -d)
 working_dir=$(mktemp -d)
@@ -59,7 +59,8 @@ export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
 # Build mssql-cli wheel from source.
 cd $source_dir
-$source_dir/python_env/bin/python3 $source_dir/build.py build;
+$source_dir/python_env/bin/python3 $source_dir/build.py dev_setup.py
+$source_dir/python_env/bin/python3 $source_dir/build.py build
 cd -
 
 # Install mssql-cli wheel.

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -58,6 +58,7 @@ export CUSTOM_PYTHON=$source_dir/python_env/bin/python3
 export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
 # Download dependencies needed to run build stage
+$source_dir/python_env/bin/python3 -m pip install --upgrade pip
 $source_dir/python_env/bin/python3 -m pip install -r $source_dir/requirements-dev.txt
 
 # Build mssql-cli wheel from source.

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -59,7 +59,6 @@ export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
 # Build mssql-cli wheel from source.
 cd $source_dir
-$source_dir/python_env/bin/python3 $source_dir/dev_setup.py
 $source_dir/python_env/bin/python3 $source_dir/build.py build
 cd -
 

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -59,7 +59,7 @@ export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
 # Build mssql-cli wheel from source.
 cd $source_dir
-$source_dir/python_env/bin/python3 $source_dir/build.py dev_setup.py
+$source_dir/python_env/bin/python3 $source_dir/dev_setup.py
 $source_dir/python_env/bin/python3 $source_dir/build.py build
 cd -
 

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -22,7 +22,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 debian_directory_creator=$script_dir/dir_creator.sh
 
 # Install dependencies for the build
-sudo apt-get install -y libssl-dev libffi-dev debhelper
+sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools
 # Download, Extract, Patch, Build CLI
 tmp_pkg_dir=$(mktemp -d)
 working_dir=$(mktemp -d)

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -22,7 +22,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 debian_directory_creator=$script_dir/dir_creator.sh
 
 # Install dependencies for the build
-sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools python3-all
+sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools python3-dev
 # Download, Extract, Patch, Build CLI
 tmp_pkg_dir=$(mktemp -d)
 working_dir=$(mktemp -d)

--- a/build_scripts/debian/dir_creator.sh
+++ b/build_scripts/debian/dir_creator.sh
@@ -54,7 +54,7 @@ Homepage: https://github.com/dbcli/mssql-cli
 
 Package: mssql-cli
 Architecture: all
-Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60
+Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60, libffi-dev
 Description: mssql-cli
     We’re excited to introduce mssql-cli, a new and interactive command line query tool for SQL Server.
     This open source tool works cross-platform and proud to be a part of the dbcli.org community.

--- a/release.py
+++ b/release.py
@@ -56,7 +56,13 @@ def _gen_pkg_index_html(service, pkg_name):
 def _upload_package(service, file_path, pkg_name):
     print('Uploading {}'.format(file_path))
     file_name = os.path.basename(file_path)
-    blob_name = 'whl/{}/{}'.format(pkg_name, file_name)
+    _, file_ext = os.path.splitext(file_name)
+
+    if file_ext == '.deb':
+        blob_name = 'deb/{}'.format(file_name)
+    else:
+        blob_name = 'whl/{}/{}'.format(pkg_name, file_name)
+
     service.create_blob_from_path(
         container_name=BLOB_CONTAINER_NAME,
         blob_name=blob_name,
@@ -115,7 +121,7 @@ def publish_daily():
     """
     Publish mssql-cli package to daily storage account.
     """
-    print('Publishing to daily container within storage account.')
+    print('Publishing wheels to daily container within storage account.')
     assert AZURE_STORAGE_CONNECTION_STRING,\
           'Set AZURE_STORAGE_CONNECTION_STRING environment variable'
 
@@ -135,12 +141,27 @@ def publish_daily():
         'Simple Index',
         UPLOADED_PACKAGE_LINKS)
 
+def publish_daily_deb():
+    """ Publish .deb package """
+    print('Publishing Debian package to daily container within storage account.')
+    assert AZURE_STORAGE_CONNECTION_STRING,\
+          'Set AZURE_STORAGE_CONNECTION_STRING environment variable'
+
+    blob_service = BlockBlobService(
+        connection_string=AZURE_STORAGE_CONNECTION_STRING)
+
+    print_heading('Uploading packages to blob storage ')
+    for pkg in os.listdir(utility.MSSQLCLI_DEB_DIRECTORY):
+        pkg_path = os.path.join(utility.MSSQLCLI_DEB_DIRECTORY, pkg)
+        print('Uploading package {}'.format(pkg_path))
+        _upload_package(blob_service, pkg_path, 'mssql-cli')
 
 if __name__ == '__main__':
     default_actions = ['download_official_wheels']
 
     targets = {
         'publish_daily': publish_daily,
+        'publish_daily_deb': publish_daily_deb,
         'publish_official': publish_official,
         'download_official_wheels': download_official_wheels
     }

--- a/utility.py
+++ b/utility.py
@@ -16,6 +16,9 @@ MSSQLCLI_DIST_DIRECTORY = os.path.abspath(
 MSSQLCLI_BUILD_DIRECTORY = os.path.abspath(
     os.path.join(os.path.abspath(__file__), '..', 'build'))
 
+MSSQLCLI_DEB_DIRECTORY = os.path.abspath(
+    os.path.join(os.path.abspath(__file__), '..', '..', 'debian_output')
+)
 
 def exec_command(command, directory, continue_on_error=True):
     """


### PR DESCRIPTION
Closes #101 and #257. Completes Debian work for #383.

This PR produces a working Debian package of mssql-cli. You may test the .deb by installing the latest dev package [here](.deb).

In addition, changes have been made to easily publish the .deb to our daily storage.

The package must be produced on an x86_64 iso of Ubuntu.