### PR TITLE
Use docker to build and deploy deb package

### DIFF
--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update
 RUN apt-get -y install python-all python3-all python3-pip python-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
 
 # Install pip and stdeb
-RUN pip3 install --upgrade pip
+RUN python -m pip install --upgrade pip
 
 # Build .deb
 RUN mkdir Repos
@@ -23,4 +23,4 @@ WORKDIR Repos/mssql-cli
 RUN build_scripts/debian/build.sh $(pwd)
 
 # Build dependencies to support publishing release of .deb
-RUN python3 -m pip install -r requirements-dev.txt
+RUN python -m pip install -r requirements-dev.txt

--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -10,10 +10,10 @@ RUN echo "connection string: ${AZURE_STORAGE_CONNECTION_STRING}"
 RUN echo "official build: ${MSSQL_CLI_OFFICIAL_BUILD}"
 
 RUN apt-get update
-RUN apt-get -y install python-all python3-all python3-pip python-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
+RUN apt-get -y install python3-all python3-pip python3-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
 
 # Install pip and stdeb
-RUN python -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip
 
 # Build .deb
 RUN mkdir Repos
@@ -23,4 +23,4 @@ WORKDIR Repos/mssql-cli
 RUN build_scripts/debian/build.sh $(pwd)
 
 # Build dependencies to support publishing release of .deb
-RUN python -m pip install -r requirements-dev.txt
+RUN python3 -m pip install -r requirements-dev.txt

--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "connection string: ${AZURE_STORAGE_CONNECTION_STRING}"
 RUN echo "official build: ${MSSQL_CLI_OFFICIAL_BUILD}"
 
 RUN apt-get update
-RUN apt-get -y install python-all python3-all python3-pip nano git sudo wget libssl-dev libffi-dev debhelper
+RUN apt-get -y install python-all python3-all python3-pip python3-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
 
 # Install pip and stdeb
 RUN pip3 install --upgrade pip

--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "connection string: ${AZURE_STORAGE_CONNECTION_STRING}"
 RUN echo "official build: ${MSSQL_CLI_OFFICIAL_BUILD}"
 
 RUN apt-get update
-RUN apt-get -y install python-all python3-all python3-pip python3-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
+RUN apt-get -y install python-all python3-all python3-pip python-setuptools nano git sudo wget libssl-dev libffi-dev debhelper
 
 # Install pip and stdeb
 RUN pip3 install --upgrade pip

--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -1,0 +1,26 @@
+# Builds .deb and installs dependencies to support release
+FROM ubuntu:16.04
+
+ARG AZURE_STORAGE_CONNECTION_STRING
+ARG MSSQL_CLI_OFFICIAL_BUILD
+
+ENV AZURE_STORAGE_CONNECTION_STRING=$AZURE_STORAGE_CONNECTION_STRING
+ENV MSSQL_CLI_OFFICIAL_BUILD=$MSSQL_CLI_OFFICIAL_BUILD
+RUN echo "connection string: ${AZURE_STORAGE_CONNECTION_STRING}"
+RUN echo "official build: ${MSSQL_CLI_OFFICIAL_BUILD}"
+
+RUN apt-get update
+RUN apt-get -y install python-all python3-all python3-pip nano git sudo wget libssl-dev libffi-dev debhelper
+
+# Install pip and stdeb
+RUN pip3 install --upgrade pip
+
+# Build .deb
+RUN mkdir Repos
+RUN mkdir Repos/mssql-cli
+ADD . Repos/mssql-cli
+WORKDIR Repos/mssql-cli
+RUN build_scripts/debian/build.sh $(pwd)
+
+# Build dependencies to support publishing release of .deb
+RUN python3 -m pip install -r requirements-dev.txt

--- a/build_scripts/debian/README.md
+++ b/build_scripts/debian/README.md
@@ -1,8 +1,24 @@
-Debian Packaging
-================
+# Debian Packaging
 
-Updating the Debian package
----------------------------
+## Build Debian Package
+
+### Build with Docker
+From the root repo directory, run:
+```
+docker build \
+--build-arg AZURE_STORAGE_CONNECTION_STRING=${AZURE_STORAGE_CONNECTION_STRING} \
+--build-arg MSSQL_CLI_OFFICIAL_BUILD=${MSSQL_CLI_OFFICIAL_BUILD} \
+-t mssqlcli-ubuntu16-build \
+-f build_scripts/debian/Dockerfile . --no-cache
+```
+
+### Release .deb to Daily Storage with Docker
+After the docker container is built, call:
+```
+docker run mssqlcli-ubuntu16-build python3 release.py publish_daily_deb
+```
+
+### Build Debian Package without Docker
 
 On a build machine (e.g. new Ubuntu 14.04 VM), run the build script.
 
@@ -18,8 +34,7 @@ Note: The paths above have to be full paths, not relative otherwise the build wi
 Now you have built the package, upload the package to the apt repository.
 
 
-Verification
-------------
+## Verification
 
 CLI_VERSION can be found in *build_scripts/debian/build.sh*
 ```

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -57,9 +57,13 @@ make install
 export CUSTOM_PYTHON=$source_dir/python_env/bin/python3
 export CUSTOM_PIP=$source_dir/python_env/bin/pip3
 
+# Download dependencies needed to run build stage
+$source_dir/python_env/bin/python3 -m pip install --upgrade pip
+$source_dir/python_env/bin/python3 -m pip install -r $source_dir/requirements-dev.txt
+
 # Build mssql-cli wheel from source.
 cd $source_dir
-$source_dir/python_env/bin/python3 $source_dir/build.py build;
+$source_dir/python_env/bin/python3 $source_dir/build.py build
 cd -
 
 # Install mssql-cli wheel.

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -22,7 +22,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 debian_directory_creator=$script_dir/dir_creator.sh
 
 # Install dependencies for the build
-sudo apt-get install -y libssl-dev libffi-dev debhelper
+sudo apt-get install -y libssl-dev libffi-dev debhelper python-setuptools
 # Download, Extract, Patch, Build CLI
 tmp_pkg_dir=$(mktemp -d)
 working_dir=$(mktemp -d)

--- a/build_scripts/debian/dir_creator.sh
+++ b/build_scripts/debian/dir_creator.sh
@@ -54,7 +54,7 @@ Homepage: https://github.com/dbcli/mssql-cli
 
 Package: mssql-cli
 Architecture: all
-Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60
+Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60, libffi-dev
 Description: mssql-cli
     We’re excited to introduce mssql-cli, a new and interactive command line query tool for SQL Server.
     This open source tool works cross-platform and proud to be a part of the dbcli.org community.

--- a/release.py
+++ b/release.py
@@ -56,7 +56,13 @@ def _gen_pkg_index_html(service, pkg_name):
 def _upload_package(service, file_path, pkg_name):
     print('Uploading {}'.format(file_path))
     file_name = os.path.basename(file_path)
-    blob_name = 'whl/{}/{}'.format(pkg_name, file_name)
+    _, file_ext = os.path.splitext(file_name)
+
+    if file_ext == '.deb':
+        blob_name = 'deb/{}'.format(file_name)
+    else:
+        blob_name = 'whl/{}/{}'.format(pkg_name, file_name)
+
     service.create_blob_from_path(
         container_name=BLOB_CONTAINER_NAME,
         blob_name=blob_name,
@@ -136,11 +142,28 @@ def publish_daily():
         UPLOADED_PACKAGE_LINKS)
 
 
+def publish_daily_deb():
+    """ Publish .deb package """
+    print('Publishing Debian package to daily container within storage account.')
+    assert AZURE_STORAGE_CONNECTION_STRING,\
+          'Set AZURE_STORAGE_CONNECTION_STRING environment variable'
+
+    blob_service = BlockBlobService(
+        connection_string=AZURE_STORAGE_CONNECTION_STRING)
+
+    print_heading('Uploading packages to blob storage ')
+    for pkg in os.listdir(utility.MSSQLCLI_DEB_DIRECTORY):
+        pkg_path = os.path.join(utility.MSSQLCLI_DEB_DIRECTORY, pkg)
+        print('Uploading package {}'.format(pkg_path))
+        _upload_package(blob_service, pkg_path, 'mssql-cli')
+
+
 if __name__ == '__main__':
     default_actions = ['download_official_wheels']
 
     targets = {
         'publish_daily': publish_daily,
+        'publish_daily_deb': publish_daily_deb,
         'publish_official': publish_official,
         'download_official_wheels': download_official_wheels
     }

--- a/utility.py
+++ b/utility.py
@@ -16,6 +16,9 @@ MSSQLCLI_DIST_DIRECTORY = os.path.abspath(
 MSSQLCLI_BUILD_DIRECTORY = os.path.abspath(
     os.path.join(os.path.abspath(__file__), '..', 'build'))
 
+MSSQLCLI_DEB_DIRECTORY = os.path.abspath(
+    os.path.join(os.path.abspath(__file__), '..', '..', 'debian_output')
+)
 
 def exec_command(command, directory, continue_on_error=True):
     """


### PR DESCRIPTION
Closes #101 and #257. Completes Debian work for #383. And closes PR #416 in favor of this one.

List of changes include:
1. **Packaging mssql-cli into .deb.** This PR produces a Debian package of mssql-cli using Docker. The package has run successfully in limited testing across Ubuntu 16.04 and 18.04, using both Docker containers and VMs.
2. **Support for automated releases in Azure DevOps Pipelines.** Using a test pipeline, I have validated that we are able to build a .deb, publish to daily storage, and download and run mssql-cli. We did this by creating a `publish_daily_deb` script in our `release.py`.
3. **Updated docs.** Documentation has been updated for building and publishing a .deb of mssql-cli in Docker.

Hopefully this implementation will prevent headaches for anyone who works on this in the future :)