### PR TITLE
Added support for Python38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: SQL',
         'Topic :: Database',
         'Topic :: Database :: Front-Ends',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py27,py36,py37,py38
 # We will build the sdist ourselves as we need to detect
 # what platform we are on and install the generated wheel
 # locally.


### PR DESCRIPTION
Updates the tox.ini file to run unit tests against Python 3.8.

PR-validation pipelines have been updated to install and use Python 3.8.