### PR TITLE
Set auto expand to false if less pager is installed

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -98,7 +98,7 @@ class MssqlCli(object):
     def set_default_pager(self, config):
         configured_pager = config['main'].get('pager')
         os_environ_pager = os.environ.get('PAGER')
-        is_less_installed = is_command_valid('less')
+        is_less_installed = is_command_valid(['less', '--version'])
         default_pager = configured_pager or os_environ_pager or \
                         ('less -SRXF' if is_less_installed else False) or None
 

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -99,15 +99,17 @@ class MssqlCli(object):
         configured_pager = config['main'].get('pager')
         os_environ_pager = os.environ.get('PAGER')
         is_less_installed = is_command_valid('less')
+        default_pager = configured_pager or os_environ_pager or \
+                        ('less -SRXF' if is_less_installed else False) or None
 
         if configured_pager:
             self.logger.info(
                 'Default pager found in config file: "%s"', configured_pager)
-            os.environ['PAGER'] = configured_pager
-        elif os_environ_pager or is_less_installed:
+        elif os_environ_pager:
             self.logger.info('Default pager found in PAGER environment variable: "%s"',
                              os_environ_pager)
-            os.environ['PAGER'] = os_environ_pager or 'less -SRXF'
+        elif is_less_installed:
+            self.logger.info('Default pager set to Less')
         else:
             self.logger.info(
                 'No default pager found in environment. Using os default pager')
@@ -117,10 +119,8 @@ class MssqlCli(object):
         if not os.environ.get('LESS'):
             os.environ['LESS'] = '-SRXF'
 
-        if 'PAGER' in os.environ.keys():
-            return os.environ['PAGER']
-        else:
-            return None
+        os.environ['PAGER'] = default_pager
+        return default_pager
 
     def __init__(self, options):
 

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -9,7 +9,6 @@ import traceback
 # pylint: disable=redefined-builtin
 from codecs import open
 from collections import namedtuple
-from shutil import which
 from time import time
 from cli_helpers.tabular_output import TabularOutputFormatter
 from cli_helpers.tabular_output.preprocessors import (align_decimals,
@@ -45,6 +44,7 @@ from mssqlcli.mssqltoolbar import create_toolbar_tokens_func
 from mssqlcli.sqltoolsclient import SqlToolsClient
 from mssqlcli.packages import special
 from mssqlcli.mssqlbuffer import mssql_is_multiline
+from mssqlcli.util import is_command_valid
 import mssqlcli.localized_strings as localized
 
 # Query tuples are used for maintaining history
@@ -98,7 +98,7 @@ class MssqlCli(object):
     def set_default_pager(self, config):
         configured_pager = config['main'].get('pager')
         os_environ_pager = os.environ.get('PAGER')
-        is_less_installed = which('less') is not None
+        is_less_installed = is_command_valid('less')
 
         if configured_pager:
             self.logger.info(

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -130,7 +130,6 @@ class MssqlCli(object):
         self.initialize_logging()
         self.logger = logging.getLogger(u'mssqlcli.main')
 
-        pager = self.set_default_pager(c)
         self.interactive_mode = options.interactive_mode
 
         self.table_format = c['main']['table_format']
@@ -138,10 +137,6 @@ class MssqlCli(object):
         self.float_format = c['data_formats']['float']
         self.null_string = c['main'].get('null_string', '<null>')
         self.expanded_output = c['main']['expand'] == 'always'
-        # set auto_expand to false if less is detected with auto expand
-        self.auto_expand = options.auto_vertical_output \
-            or (c['main']['expand'] == 'auto' and pager != 'less -SRXF')
-        self.prompt_session = None
         self.integrated_auth = options.integrated_auth
         self.less_chatty = bool(
             options.less_chatty) or c['main'].as_bool('less_chatty') or self.interactive_mode
@@ -161,6 +156,12 @@ class MssqlCli(object):
         }
 
         if self.interactive_mode:
+            pager = self.set_default_pager(c)
+            self.prompt_session = None
+
+            # set auto_expand to false if less is detected with auto expand
+            self.auto_expand = options.auto_vertical_output \
+                or (c['main']['expand'] == 'auto' and pager != 'less -SRXF')
             self.multiline = c['main'].as_bool('multi_line')
             self.multiline_mode = c['main'].get('multi_line_mode', 'tsql')
             self.vi_mode = c['main'].as_bool('vi')
@@ -568,7 +569,7 @@ class MssqlCli(object):
                 all_success = False
                 continue
 
-            if self.auto_expand and self.prompt_session:
+            if self.interactive_mode and self.auto_expand and self.prompt_session:
                 max_width = self.prompt_session.output.get_size().columns
             else:
                 max_width = None

--- a/mssqlcli/util.py
+++ b/mssqlcli/util.py
@@ -23,6 +23,9 @@ def is_command_valid(command):
     Checks if command is recognized on machine. Used to determine installations
     of 'less' pager.
     """
+    if not command:
+        return False
+
     try:
         # call command silentyly
         with open(devnull, 'wb') as no_out:

--- a/mssqlcli/util.py
+++ b/mssqlcli/util.py
@@ -1,3 +1,6 @@
+from os import devnull
+import subprocess
+
 def encode(s):
     try:
         return s.encode('utf-8')
@@ -14,3 +17,17 @@ def decode(s):
     except (AttributeError, SyntaxError, UnicodeEncodeError):
         pass
     return s
+
+def is_command_valid(command):
+    """
+    Checks if command is recognized on machine. Used to determine installations
+    of 'less' pager.
+    """
+    try:
+        # call command silentyly
+        with open(devnull, 'wb') as no_out:
+            subprocess.call(command, stdout=no_out, stderr=no_out)
+    except OSError:
+        return False
+    else:
+        return True

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
 from mssqlcli.mssql_cli import MssqlCli
+from mssqlcli.config import get_config
 from mssqlcli.mssqlclioptionsparser import create_parser
 from utility import random_str
 
@@ -69,6 +70,14 @@ def create_mssql_cli_options(**nondefault_options):
         return Namespace(**updateable_mssql_cli_options)
 
     return default_mssql_cli_options
+
+def create_mssql_cli_config(options=None):
+    """
+    Create config from options.
+    """
+    if not options:
+        options = create_mssql_cli_options()
+    return get_config(options.mssqlclirc_file)
 
 def shutdown(connection):
     connection.shutdown()

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -1,13 +1,19 @@
+import os
 import pytest
+from mssqlcli.util import is_command_valid
 from mssqltestutils import (
     create_mssql_cli,
+    create_mssql_cli_config,
     shutdown,
     test_queries,
     get_file_contents,
     get_io_paths
 )
 
-class TestInteractiveModeQueries:
+class TestInteractiveMode:
+    """
+    Fixture used at class-level.
+    """
     @staticmethod
     @pytest.fixture(scope='class')
     def mssqlcli():
@@ -19,6 +25,7 @@ class TestInteractiveModeQueries:
         yield mssqlcli
         shutdown(mssqlcli)
 
+class TestInteractiveModeQueries(TestInteractiveMode):
     @staticmethod
     @pytest.mark.parametrize("query_str, test_file", test_queries)
     @pytest.mark.timeout(60)
@@ -73,3 +80,41 @@ class TestInteractiveModeInvalidRuns:
         finally:
             if mssqlcli is not None:
                 shutdown(mssqlcli)
+
+class TestInteractiveModePager(TestInteractiveMode):
+    """
+    Test default pager setting.
+    """
+
+    @staticmethod
+    @pytest.mark.timeout(60)
+    def test_pager_environ(mssqlcli):
+        os.environ['PAGER'] = 'testing environ value'
+
+        config = create_mssql_cli_config()
+        assert mssqlcli.set_default_pager(config) == 'testing environ value'
+
+        os.environ['PAGER'] = 'less -SRXF'
+        assert mssqlcli.set_default_pager(config) == 'less -SRXF'
+
+    @staticmethod
+    @pytest.mark.timeout(60)
+    def test_pager_config(mssqlcli):
+        # defaults to config value over os.environ
+        os.environ['PAGER'] = 'less -SRXF'
+        config_value = 'testing config value'
+
+        config = create_mssql_cli_config()
+        config['main']['pager'] = config_value
+        assert mssqlcli.set_default_pager(config) == config_value
+
+    @staticmethod
+    @pytest.mark.timeout(60)
+    def test_valid_command():
+        assert is_command_valid('cd')
+
+    @staticmethod
+    @pytest.mark.timeout(60)
+    def test_invalid_command():
+        assert not is_command_valid(None)
+        assert not is_command_valid('')

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pytest
+import utility
 from mssqlcli.util import is_command_valid
 from mssqltestutils import (
     create_mssql_cli,
@@ -96,7 +97,11 @@ class TestInteractiveModePager(TestInteractiveMode):
         os.environ['PAGER'] = 'testing environ value'
 
         config = create_mssql_cli_config()
-        config['main'].pop('pager')     # remove config pager value
+
+        # remove config pager value if exists
+        if 'pager' in config['main'].keys():
+            config['main'].pop('pager')
+
         assert mssqlcli.set_default_pager(config) == 'testing environ value'
 
         os.environ['PAGER'] = 'less -SRXF'
@@ -125,8 +130,8 @@ class TestInteractiveModePager(TestInteractiveMode):
             exe_name = 'mssql-cli.bat'
         else:
             exe_name = 'mssql-cli'
-        mssqlcli_path = os.path.join('.', exe_name)
-        assert is_command_valid(mssqlcli_path)
+
+        assert is_command_valid([os.path.join(utility.ROOT_DIR, exe_name), '--version'])
 
     @staticmethod
     @pytest.mark.timeout(60)

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 from mssqlcli.util import is_command_valid
 from mssqltestutils import (
@@ -89,9 +90,13 @@ class TestInteractiveModePager(TestInteractiveMode):
     @staticmethod
     @pytest.mark.timeout(60)
     def test_pager_environ(mssqlcli):
+        """
+        Defaults to environment variable with no config value for pager
+        """
         os.environ['PAGER'] = 'testing environ value'
 
         config = create_mssql_cli_config()
+        config['main'].pop('pager')     # remove config pager value
         assert mssqlcli.set_default_pager(config) == 'testing environ value'
 
         os.environ['PAGER'] = 'less -SRXF'
@@ -100,7 +105,9 @@ class TestInteractiveModePager(TestInteractiveMode):
     @staticmethod
     @pytest.mark.timeout(60)
     def test_pager_config(mssqlcli):
-        # defaults to config value over os.environ
+        """
+        Defaults to config value over environment variable
+        """
         os.environ['PAGER'] = 'less -SRXF'
         config_value = 'testing config value'
 
@@ -111,7 +118,15 @@ class TestInteractiveModePager(TestInteractiveMode):
     @staticmethod
     @pytest.mark.timeout(60)
     def test_valid_command():
-        assert is_command_valid('cd')
+        """
+        Checks valid command by running mssql-cli executable in repo
+        """
+        if sys.platform == 'win32':
+            exe_name = 'mssql-cli.bat'
+        else:
+            exe_name = 'mssql-cli'
+        mssqlcli_path = os.path.join('.', exe_name)
+        assert is_command_valid(mssqlcli_path)
 
     @staticmethod
     @pytest.mark.timeout(60)


### PR DESCRIPTION
This PR brings support for horizontal paging out-of-the-box, given the following criteria are met:
1. less is installed on machine, and
2. vertical output setting is set to auto or never

For Linux users, this should bring horizontal paging as a standard experience, given that less is usually installed by default.

Tag: #411