### PR TITLE
Fixed unit test fail when optout variable isn't set

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -25,7 +25,8 @@ class TelemetryTests(unittest.TestCase):
         import mssqlcli.telemetry as telemetry      # pylint: disable=import-outside-toplevel
         return telemetry
 
-    @unittest.skipUnless(os.environ['MSSQL_CLI_TELEMETRY_OPTOUT'].lower() != 'true',
+    @unittest.skipUnless('MSSQL_CLI_TELEMETRY_OPTOUT' in os.environ.keys() and
+                         os.environ['MSSQL_CLI_TELEMETRY_OPTOUT'].lower() != 'true',
                          "Only works when telemetry opt-out not set to true.")
     def test_telemetry_data_points(self):
         test_telemetry_client = self.build_telemetry_client()


### PR DESCRIPTION
The telemetry unit test we recently set to 'skip' in our Azure pipelines will fail if run on a machine that doesn't set the `MSSQL_CLI_TELEMETRY_OPTOUT` environment variable. This mostly affects local testing.