### PR TITLE
Fixed bug which caused some queries with semicolons to crash

### DIFF
--- a/mssqlcli/mssqlcliclient.py
+++ b/mssqlcli/mssqlcliclient.py
@@ -106,7 +106,7 @@ class MssqlCliClient:
             else:
                 for single_query in sqlparse.split(query):
                     # Remove spaces, EOL and semi-colons from end
-                    single_query = single_query.strip().rstrip(';')
+                    single_query = single_query.strip()
                     if single_query:
                         for rows, columns, status, statement, is_error \
                             in self._execute_query(single_query):

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -240,7 +240,7 @@ class TestMssqlCliClientMultipleStatement(MssqlCliClient):
         for (i, (rows, _, _, query_executed, is_error)) in \
             enumerate(client.execute_query(query_str)):
 
-            queries = query_str.split(';')
+            queries = ["{};".format(query) for query in query_str.split(';')]
             assert query_executed == queries[i].strip()
             assert len(rows) == rows_outputted[i]
             assert (is_error and len(rows) == 0) or (not is_error)

--- a/tests/test_mssqlcliclient.py
+++ b/tests/test_mssqlcliclient.py
@@ -12,7 +12,9 @@ from mssqltestutils import (
     create_test_db,
     clean_up_test_db,
     shutdown,
-    random_str
+    random_str,
+    get_io_paths,
+    get_file_contents
 )
 
 
@@ -244,3 +246,16 @@ class TestMssqlCliClientMultipleStatement(MssqlCliClient):
             assert query_executed == queries[i].strip()
             assert len(rows) == rows_outputted[i]
             assert (is_error and len(rows) == 0) or (not is_error)
+
+    @staticmethod
+    def test_mssqlcliclient_multiple_merge(client_with_db):
+        """
+        Tests query with multiple merges. Requires creation of temp db.
+        """
+        file_input, _ = get_io_paths('multiple_merge.txt')
+        query_input = get_file_contents(file_input)
+
+        for rows, _, status, _, is_error in client_with_db.execute_query(query_input):
+            if is_error:
+                raise AssertionError("Query execution failed: {}".format(status))
+            assert () == rows

--- a/tests/test_noninteractive_mode.py
+++ b/tests/test_noninteractive_mode.py
@@ -6,6 +6,8 @@ import subprocess
 import pytest
 from mssqltestutils import (
     create_mssql_cli,
+    create_test_db,
+    clean_up_test_db,
     random_str,
     shutdown,
     test_queries,
@@ -79,6 +81,25 @@ class TestNonInteractiveResults:
             assert output_query_from_file == output_baseline
         finally:
             shutdown(mssqlcli)
+
+    @pytest.mark.timeout(300)
+    def test_multiple_merge(self):
+        """
+        Tests query with multiple merges. Requires creation of temp db.
+        """
+        try:
+            # create temporary db
+            db_name = create_test_db()
+
+            file_input, file_baseline = get_io_paths('multiple_merge.txt')
+            text_baseline = get_file_contents(file_baseline)
+
+            # test with -i
+            output_query = self.execute_query_via_subprocess("-i {} -d {}"\
+                                                             .format(file_input, db_name))
+            assert output_query == text_baseline
+        finally:
+            clean_up_test_db(db_name)
 
     @classmethod
     @pytest.mark.timeout(60)

--- a/tests/test_query_baseline/baseline_multiple_merge.txt
+++ b/tests/test_query_baseline/baseline_multiple_merge.txt
@@ -1,0 +1,9 @@
+Commands completed successfully.
+Commands completed successfully.
+(4 rows affected)
+Commands completed successfully.
+Commands completed successfully.
+(5 rows affected)
+(6 rows affected)
+(5 rows affected)
+Commands completed successfully.

--- a/tests/test_query_inputs/input_multiple_merge.txt
+++ b/tests/test_query_inputs/input_multiple_merge.txt
@@ -1,0 +1,62 @@
+--Example taken from https://www.sqlservertutorial.net/sql-server-basics/sql-server-merge/
+
+drop table if exists  dbo.category;
+CREATE TABLE dbo.category (
+    category_id INT PRIMARY KEY,
+    category_name VARCHAR(255) NOT NULL,
+    amount DECIMAL(10 , 2 )
+);
+
+INSERT INTO dbo.category(category_id, category_name, amount)
+VALUES(1,'Children Bicycles',15000),
+    (2,'Comfort Bicycles',25000),
+    (3,'Cruisers Bicycles',13000),
+    (4,'Cyclocross Bicycles',10000);
+
+drop table if exists dbo.category_staging;
+CREATE TABLE dbo.category_staging (
+    category_id INT PRIMARY KEY,
+    category_name VARCHAR(255) NOT NULL,
+    amount DECIMAL(10 , 2 )
+);
+
+INSERT INTO dbo.category_staging(category_id, category_name, amount)
+VALUES(1,'Children Bicycles',15000),
+    (3,'Cruisers Bicycles',13000),
+    (4,'Cyclocross Bicycles',20000),
+    (5,'Electric Bikes',10000),
+    (6,'Mountain Bikes',10000);
+
+
+go
+
+--Do the merge
+MERGE dbo.category t
+    USING dbo.category_staging s
+ON (s.category_id = t.category_id)
+WHEN MATCHED
+    THEN UPDATE SET
+        t.category_name = s.category_name,
+        t.amount = s.amount
+WHEN NOT MATCHED BY TARGET
+    THEN INSERT (category_id, category_name, amount)
+         VALUES (s.category_id, s.category_name, s.amount)
+WHEN NOT MATCHED BY SOURCE
+    THEN DELETE;
+
+go
+
+--Do the exact same statement (cut/pasted)
+MERGE dbo.category t
+    USING dbo.category_staging s
+ON (s.category_id = t.category_id)
+WHEN MATCHED
+    THEN UPDATE SET
+        t.category_name = s.category_name,
+        t.amount = s.amount
+WHEN NOT MATCHED BY TARGET
+    THEN INSERT (category_id, category_name, amount)
+         VALUES (s.category_id, s.category_name, s.amount)
+WHEN NOT MATCHED BY SOURCE
+    THEN DELETE;
+go

--- a/tests/test_query_inputs/input_multiple_merge.txt
+++ b/tests/test_query_inputs/input_multiple_merge.txt
@@ -1,5 +1,3 @@
---Example taken from https://www.sqlservertutorial.net/sql-server-basics/sql-server-merge/
-
 drop table if exists  dbo.category;
 CREATE TABLE dbo.category (
     category_id INT PRIMARY KEY,


### PR DESCRIPTION
Fixes #422 

The mssql-cli client uses old and unnecessary logic to right-strip semicolons. This was introduced in a refactor a few years ago, making it unclear why it was added in the first place. All of our tests passed after removing the semicolon-strip logic, however we needed to make minor updates to a few tests to expect semicolons in the input text.

This PR also introduces new tests to ensure the script in the #422 bug report work in multiline and non-interactive modes.