### PR TITLE
Changed switch statement to convert string to lowercase

### DIFF
--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -12,7 +12,8 @@ local_repo=$1
 
 sudo apt-get update
 
-if [ "${MSSQL_CLI_OFFICIAL_BUILD}" != "True" ]
+# the ',,' makes environment variable lower case in Bash 4+
+if [ "${MSSQL_CLI_OFFICIAL_BUILD,,}" != "true" ]
     then
         time_stamp=$(date +%y%m%d%H%M)
         CLI_VERSION=$CLI_VERSION.dev$time_stamp

--- a/build_scripts/rpm/build.sh
+++ b/build_scripts/rpm/build.sh
@@ -16,6 +16,10 @@ sudo yum install -y gcc git rpm-build rpm-devel rpmlint make bash diffutils patc
 rm -rf ~/rpmbuild
 rm -rf ${REPO_PATH}/../rpm_output
 
+# the ',,' makes environment variable lower case in Bash 4+
+# needed before switch statement checks for 'true'
+MSSQL_CLI_OFFICIAL_BUILD="${MSSQL_CLI_OFFICIAL_BUILD,,}"
+
 # Build rpm package
 rpmbuild -v -bb --clean ${REPO_PATH}/build_scripts/rpm/mssql-cli.spec
 

--- a/build_scripts/rpm/mssql-cli.spec
+++ b/build_scripts/rpm/mssql-cli.spec
@@ -18,7 +18,8 @@
 %define repo_path      %{getenv:REPO_PATH}
 %define official_build %{getenv:MSSQL_CLI_OFFICIAL_BUILD}
 
-%if "%{official_build}" != "True"
+# the ',,' makes environment variable lower case in Bash 4+
+%if "%{official_build,,}" != "true"
   %define version %{base_version}.dev%{time_stamp}
 %else
   %define version %{base_version}

--- a/build_scripts/rpm/mssql-cli.spec
+++ b/build_scripts/rpm/mssql-cli.spec
@@ -19,7 +19,7 @@
 %define official_build %{getenv:MSSQL_CLI_OFFICIAL_BUILD}
 
 # the ',,' makes environment variable lower case in Bash 4+
-%if "%{official_build,,}" != "true"
+%if "%{official_build}" != "true"
   %define version %{base_version}.dev%{time_stamp}
 %else
   %define version %{base_version}


### PR DESCRIPTION
Fixes issue where switch statement would check if `MSSQL_CLI_OFFICIAL_BUILD` would be equal to the `"True"` string, without taking casing into account. This was only impacting deb and rpm packaging. Proposed solution uses a command that's supported in Bash 4.0+.

I have validated that this fix is compatible with our Dockerized approach to building Linux packages. This is currently being tested for compatibility with Azure DevOps.