### PR TITLE
Fixed bug that caused interactive mode to crash

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -119,7 +119,8 @@ class MssqlCli(object):
         if not os.environ.get('LESS'):
             os.environ['LESS'] = '-SRXF'
 
-        os.environ['PAGER'] = default_pager
+        if default_pager is not None:
+            os.environ['PAGER'] = default_pager
         return default_pager
 
     def __init__(self, options):


### PR DESCRIPTION
Our recent less-autodetect PR introduced a bug that's fixed in this PR. In environments where less is not installed, and where no alternative is determined, we were setting the `PAGER` environment variable to `None` Python type. Because the shell doesn't know what a `None` is, it crashes.