### PR TITLE
Added requirement for Less on Linux

### DIFF
--- a/build_scripts/debian/dir_creator.sh
+++ b/build_scripts/debian/dir_creator.sh
@@ -54,7 +54,7 @@ Homepage: https://github.com/dbcli/mssql-cli
 
 Package: mssql-cli
 Architecture: all
-Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60, libffi-dev
+Depends: libunwind8, libicu52 | libicu55 | libicu57 | libicu60, libffi-dev, less
 Description: mssql-cli
     We’re excited to introduce mssql-cli, a new and interactive command line query tool for SQL Server.
     This open source tool works cross-platform and proud to be a part of the dbcli.org community.

--- a/build_scripts/rpm/mssql-cli.spec
+++ b/build_scripts/rpm/mssql-cli.spec
@@ -39,7 +39,7 @@ BuildRequires:  libffi-devel
 BuildRequires:  openssl-devel
 BuildRequires:  /usr/bin/pathfix.py
 
-Requires:       libunwind, libicu
+Requires:       libunwind, libicu, less
 
 %description
     We’re excited to introduce mssql-cli, a new and interactive command line query tool for SQL Server.


### PR DESCRIPTION
Some Linux distributions will not come with Less installed. This PR introduces an install-time requirement to ensure users install Less.

On Ubuntu, it is already required to call `apt-get install -f` to install missing requirements, so this won't introduce an extra step. On CentOS, Less appears to already be installed on the platform.