### PR TITLE
Updated stable download links

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,3 +11,5 @@ serialize =
 [bumpversion:file:build_scripts/rpm/mssql-cli.spec]
 
 [bumpversion:file:release_scripts/Packages.Microsoft/publish.sh]
+
+[bumpversion:file:doc/installation/README.md]

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -16,10 +16,10 @@ also be found in the links above.
 
 | Supported Platform                         |Latest Stable                 |
 |--------------------------------------------|------------------------------|
-|  Windows (x64)                             |[.whl][whl-win-x64]           |
-|  Windows (x86)                             |[.whl][whl-win-x86]           |
-|  macOS 10.12+                              |[.whl][whl-macos]             |
-|  Linux (Python Wheel)                      |[.whl][whl-linux]             |
+|  Windows (x64)                             |[.whl][whl]           |
+|  Windows (x86)                             |[.whl][whl]           |
+|  macOS 10.12+                              |[.whl][whl]             |
+|  Linux (Python Wheel)                      |[.whl][whl]             |
 |  Ubuntu 14.04+                             |[.deb][deb]                   |
 |  Debian 8.7+                               |[.deb][deb]                   |
 |  CentOS 7+                                 |[.rpm][rpm]                   |
@@ -28,14 +28,8 @@ also be found in the links above.
 |  Fedora 25+                                |[.rpm][rpm]                   |
 
 
-[deb]: https://mssqlcli.blob.core.windows.net/daily/deb/mssql-cli_0.18.1-1_all.deb
+[deb]: https://packages.microsoft.com/ubuntu/16.04/prod/pool/main/m/mssql-cli/mssql-cli_1.0.0-1_all.deb
 
-[rpm]: https://mssqlcli.blob.core.windows.net/daily/rpm/mssql-cli-0.18.1-1.el8.x86_64.rpm
+[rpm]: https://packages.microsoft.com/centos/7/prod/mssql-cli-1.0.0-1.el7.x86_64.rpm
 
-[whl-win-x64]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-win_amd64.whl
-
-[whl-win-x86]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-win32.whl
-
-[whl-macos]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-macosx_10_11_intel.whl
-
-[whl-linux]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-manylinux1_x86_64.whl
+[whl]: https://pypi.org/manage/project/mssql-cli/release/1.0.0/

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -16,10 +16,10 @@ also be found in the links above.
 
 | Supported Platform                         |Latest Stable                 |
 |--------------------------------------------|------------------------------|
-|  Windows (x64)                             |[.whl][whl]           |
-|  Windows (x86)                             |[.whl][whl]           |
-|  macOS 10.12+                              |[.whl][whl]             |
-|  Linux (Python Wheel)                      |[.whl][whl]             |
+|  Windows (x64)                             |[.whl][whl-win-x64]           |
+|  Windows (x86)                             |[.whl][whl-win-x86]           |
+|  macOS 10.12+                              |[.whl][whl-macos]             |
+|  Linux (Python Wheel)                      |[.whl][whl-linux]             |
 |  Ubuntu 14.04+                             |[.deb][deb]                   |
 |  Debian 8.7+                               |[.deb][deb]                   |
 |  CentOS 7+                                 |[.rpm][rpm]                   |
@@ -28,8 +28,14 @@ also be found in the links above.
 |  Fedora 25+                                |[.rpm][rpm]                   |
 
 
-[deb]: https://packages.microsoft.com/ubuntu/16.04/prod/pool/main/m/mssql-cli/mssql-cli_1.0.0-1_all.deb
+[deb]: https://packages.microsoft.com/ubuntu/16.04/prod/pool/main/m/mssql-cli/mssql-cli_0.18.1-1_all.deb
 
-[rpm]: https://packages.microsoft.com/centos/7/prod/mssql-cli-1.0.0-1.el7.x86_64.rpm
+[rpm]: https://packages.microsoft.com/centos/7/prod/mssql-cli-0.18.1-1.el7.x86_64.rpm
 
-[whl]: https://pypi.org/manage/project/mssql-cli/release/1.0.0/
+[whl-win-x64]: https://files.pythonhosted.org/packages/b3/d9/f7c5eb456ef5f000ff3ff9b79bd6ab1e3ac679316d7ef4238fb7b56c2ca8/mssql_cli-0.18.2-py2.py3-none-win_amd64.whl
+
+[whl-win-x86]: https://files.pythonhosted.org/packages/dd/a6/aaeb23178ca818256293a4435da661572957482e324c640a69f59e0696bd/mssql_cli-0.18.2-py2.py3-none-win32.whl
+
+[whl-macos]: https://files.pythonhosted.org/packages/84/63/a7a13544f2c5be41e5446c4630bce924e0f8646238e7aae2687c319279ae/mssql_cli-0.18.2-py2.py3-none-macosx_10_11_intel.whl
+
+[whl-linux]: https://files.pythonhosted.org/packages/80/1f/3e6f6ff9f873b78e525304aca86ae78cbf9ca82a8aeba718e5b71bdf6dc4/mssql_cli-0.18.2-py2.py3-none-manylinux1_x86_64.whl

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -19,6 +19,7 @@ also be found in the links above.
 |  Windows (x64)                             |[.whl][whl-win-x64]           |
 |  Windows (x86)                             |[.whl][whl-win-x86]           |
 |  macOS 10.12+                              |[.whl][whl-macos]             |
+|  Linux (Python Wheel)                      |[.whl][whl-linux]             |
 |  Ubuntu 14.04+                             |[.deb][deb]                   |
 |  Debian 8.7+                               |[.deb][deb]                   |
 |  CentOS 7+                                 |[.rpm][rpm]                   |
@@ -26,8 +27,15 @@ also be found in the links above.
 |  openSUSE                                  |[.rpm][rpm]                   |
 |  Fedora 25+                                |[.rpm][rpm]                   |
 
-[deb]: https://packages.microsoft.com/ubuntu/14.04/prod/pool/main/m/mssql-cli/mssql-cli_0.15.0-1_all.deb
-[rpm]: https://packages.microsoft.com/rhel/7/prod/mssql-cli-0.15.0-1.el7.x86_64.rpm
-[whl-win-x64]: https://files.pythonhosted.org/packages/79/31/1be42f3632a30bb126e02cda4312b797f5f2cdef60b9c62596196a475037/mssql_cli-0.15.0-py2.py3-none-win_amd64.whl
-[whl-win-x86]: https://files.pythonhosted.org/packages/21/8c/9829c2094b4f179f9c2f4548b2ba089867f84a3758cb70575ef2a905e877/mssql_cli-0.15.0-py2.py3-none-win32.whl
-[whl-macos]: https://files.pythonhosted.org/packages/43/5d/c9af6aec5b491e7b0c5ccf00b4b8062282d6c4cfb4c0417891bd6013e299/mssql_cli-0.15.0-py2.py3-none-macosx_10_11_intel.whl
+
+[deb]: https://mssqlcli.blob.core.windows.net/daily/deb/mssql-cli_0.18.1-1_all.deb
+
+[rpm]: https://mssqlcli.blob.core.windows.net/daily/rpm/mssql-cli-0.18.1-1.el8.x86_64.rpm
+
+[whl-win-x64]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-win_amd64.whl
+
+[whl-win-x86]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-win32.whl
+
+[whl-macos]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-macosx_10_11_intel.whl
+
+[whl-linux]: https://mssqlcli.blob.core.windows.net/daily/whl/mssql-cli/mssql_cli-0.18.1-py2.py3-none-manylinux1_x86_64.whl

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -28,14 +28,14 @@ also be found in the links above.
 |  Fedora 25+                                |[.rpm][rpm]                   |
 
 
-[deb]: https://packages.microsoft.com/ubuntu/16.04/prod/pool/main/m/mssql-cli/mssql-cli_0.18.1-1_all.deb
+[deb]: https://packages.microsoft.com/ubuntu/16.04/prod/pool/main/m/mssql-cli/mssql-cli_1.0.0-1_all.deb
 
-[rpm]: https://packages.microsoft.com/centos/7/prod/mssql-cli-0.18.1-1.el7.x86_64.rpm
+[rpm]: https://packages.microsoft.com/centos/7/prod/mssql-cli-1.0.0-1.el7.x86_64.rpm
 
-[whl-win-x64]: https://files.pythonhosted.org/packages/b3/d9/f7c5eb456ef5f000ff3ff9b79bd6ab1e3ac679316d7ef4238fb7b56c2ca8/mssql_cli-0.18.2-py2.py3-none-win_amd64.whl
+[whl-win-x64]: https://files.pythonhosted.org/packages/f6/cd/cf9be6175ccc241fd70e11e8d8d6455a630e06ffe1c937034b37e1301b2c/mssql_cli-1.0.0-py2.py3-none-win_amd64.whl
 
-[whl-win-x86]: https://files.pythonhosted.org/packages/dd/a6/aaeb23178ca818256293a4435da661572957482e324c640a69f59e0696bd/mssql_cli-0.18.2-py2.py3-none-win32.whl
+[whl-win-x86]: https://files.pythonhosted.org/packages/08/e0/38d4721bcc0f5f013e8a05b722f55675185dc9e62f460a8615f25e4f0098/mssql_cli-1.0.0-py2.py3-none-win32.whl
 
-[whl-macos]: https://files.pythonhosted.org/packages/84/63/a7a13544f2c5be41e5446c4630bce924e0f8646238e7aae2687c319279ae/mssql_cli-0.18.2-py2.py3-none-macosx_10_11_intel.whl
+[whl-macos]: https://files.pythonhosted.org/packages/14/2f/8ba644a5f8a51048a749441113acd51df282b20ad1497b2aaf599adb10db/mssql_cli-1.0.0-py2.py3-none-macosx_10_11_intel.whl
 
-[whl-linux]: https://files.pythonhosted.org/packages/80/1f/3e6f6ff9f873b78e525304aca86ae78cbf9ca82a8aeba718e5b71bdf6dc4/mssql_cli-0.18.2-py2.py3-none-manylinux1_x86_64.whl
+[whl-linux]: https://files.pythonhosted.org/packages/46/98/257260e7a520291de8168c91bb10778dcae324e2a236e856dd3cce7fe0b1/mssql_cli-1.0.0-py2.py3-none-manylinux1_x86_64.whl

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -112,15 +112,26 @@ To uninstall mssql-cli, call `sudo apt-get remove mssql-cli`.
 > This package also works on Oracle Linux 7.
 
 ```sh
+# Import the public repository GPG keys
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Register the Microsoft product feed
 sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+
+# Install dependencies and mssql-cli
 sudo yum install libunwind
 sudo yum install mssql-cli
 ```
 
 #### CentOS 8
-
 ```sh
+# Import the public repository GPG keys
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Register the Microsoft product feed
 sudo rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm
+
+# Install dependencies and mssql-cli
 sudo yum install libunwind
 sudo yum install mssql-cli
 ```
@@ -129,7 +140,13 @@ sudo yum install mssql-cli
 
 #### RHEL 7
 ```sh
+# Import the public repository GPG keys
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Register the Microsoft product feed
 sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+
+# Install dependencies and mssql-cli
 sudo yum install libunwind
 sudo yum install mssql-cli
 ```

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -116,7 +116,7 @@ To uninstall mssql-cli, call `sudo apt-get remove mssql-cli`.
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # Register the Microsoft product feed
-sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+curl https://packages.microsoft.com/config/centos/7/prod.repo > /etc/yum.repos.d/msprod.repo
 
 # Install dependencies and mssql-cli
 sudo yum install libunwind
@@ -129,7 +129,7 @@ sudo yum install mssql-cli
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # Register the Microsoft product feed
-sudo rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm
+curl https://packages.microsoft.com/config/cenots/8/prod.repo > /etc/yum.repos.d/msprod.repo
 
 # Install dependencies and mssql-cli
 sudo yum install libunwind
@@ -144,7 +144,7 @@ sudo yum install mssql-cli
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # Register the Microsoft product feed
-sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo
 
 # Install dependencies and mssql-cli
 sudo yum install libunwind

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -37,6 +37,9 @@ sudo apt-get update
 
 # Install mssql-cli
 sudo apt-get install mssql-cli
+
+# Install missing dependencies
+sudo apt-get install -f
 ```
 
 #### Ubuntu 16.04 (Xenial)
@@ -52,6 +55,9 @@ sudo apt-get update
 
 # Install mssql-cli
 sudo apt-get install mssql-cli
+
+# Install missing dependencies
+sudo apt-get install -f
 ```
 
 ### Debian
@@ -70,6 +76,9 @@ sudo apt-get update
 
 # Install mssql-cli
 sudo apt-get install mssql-cli
+
+# Install missing dependencies
+sudo apt-get install -f
 ```
 
 #### Debian 9
@@ -85,6 +94,9 @@ sudo apt-get update
 
 # Install mssql-cli
 sudo apt-get install mssql-cli
+
+# Install missing dependencies
+sudo apt-get install -f
 ```
 
 ### Upgrade on Ubuntu/Debian
@@ -103,15 +115,23 @@ To uninstall mssql-cli, call `sudo apt-get remove mssql-cli`.
 > This package also works on Oracle Linux 7.
 
 ```sh
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo curl -o /etc/yum.repos.d/mssql-cli.repo https://packages.microsoft.com/config/rhel/7/prod.repo
+sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+sudo yum install libunwind
+sudo yum install mssql-cli
+```
+
+#### CentOS 8
+
+```sh
+sudo rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm
+sudo yum install libunwind
 sudo yum install mssql-cli
 ```
 
 #### Red Hat Enterprise Linux (RHEL) 7
 ```sh
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo
+sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+sudo yum install libunwind
 sudo yum install mssql-cli
 ```
 

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -3,34 +3,31 @@ Stable installations of mssql-cli on Linux are hosted in the [Microsoft Linux So
 
 [**Debian-based**](#Debian-based)
 - [**Ubuntu**](#Ubuntu)
-    - [Ubuntu 14.04 (Trusty)](#ubuntu-1404-Trusty)
     - [Ubuntu 16.04 (Xenial)](#ubuntu-1604-Xenial)
+    - [Ubuntu 18.04 (Bionic)](#ubuntu-1804-Bionic)
 - [**Debian**](#Debian)
     - [Debian 8](#debian-8)
     - [Debian 9](#debian-9)
 
 [**RPM-based**](#RPM-based)
-- [**CentOS/RHEL**](#CentOSRHEL)
+- [**CentOS**](#CentOS)
     - [CentOS 7](#centos-7)
-    - [Red Hat Enterprise Linux (RHEL) 7](#red-hat-enterprise-linux-rhel-7)
-- [**openSUSE**](#opensuse)
-    - [openSUSE 42.2](#opensuse-422)
-- [**Fedora**](#fedora)
-    - [Fedora 25](#fedora-25)
-    - [Fedora 26](#fedora-26)
+    - [CentOS 8](#centos-8)
+- [**Red Hat Enterprise Linux**](#Red-Hat-Enterprise-Linux)
+    - [RHEL 7](#RHEL-7)
 
 
 ## Debian-based
 
 ### Ubuntu
 
-#### Ubuntu 14.04 (Trusty)
+#### Ubuntu 16.04 (Xenial)
 ```sh
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
 # Register the Microsoft Ubuntu repository
-sudo apt-add-repository https://packages.microsoft.com/ubuntu/14.04/prod
+sudo apt-add-repository https://packages.microsoft.com/ubuntu/16.04/prod
 
 # Update the list of products
 sudo apt-get update
@@ -42,13 +39,13 @@ sudo apt-get install mssql-cli
 sudo apt-get install -f
 ```
 
-#### Ubuntu 16.04 (Xenial)
+#### Ubuntu 18.04 (Bionic)
 ```sh
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
 # Register the Microsoft Ubuntu repository
-sudo apt-add-repository https://packages.microsoft.com/ubuntu/16.04/prod
+sudo apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod
 
 # Update the list of products
 sudo apt-get update
@@ -109,7 +106,7 @@ To uninstall mssql-cli, call `sudo apt-get remove mssql-cli`.
 
 ## RPM-based
 
-### CentOS/RHEL
+### CentOS
 
 #### CentOS 7
 > This package also works on Oracle Linux 7.
@@ -128,7 +125,9 @@ sudo yum install libunwind
 sudo yum install mssql-cli
 ```
 
-#### Red Hat Enterprise Linux (RHEL) 7
+### Red Hat Enterprise Linux
+
+#### RHEL 7
 ```sh
 sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
 sudo yum install libunwind
@@ -141,60 +140,3 @@ from then on, you just need to use `sudo yum update mssql-cli` to update it.
 
 ### Uninstall on CentOS/RHEL
 To uninstall mssql-cli, call `sudo yum remove mssql-cli`.
-
-
-## openSUSE
-
-### openSUSE
-
-#### openSUSE 42.2
-
-mssql-cli for Linux is published to official Microsoft repositories for easy installation (and updates).
-
-```sh
-# Add openSUSE repository feed
-sudo zypper addrepo https://download.opensuse.org/repositories/server:monitoring/openSUSE_Leap_42.2/server:monitoring.repo
-
-# Add the Microsoft Product feed
-sudo zypper addrepo -fc https://packages.microsoft.com/config/opensuse/42.2/prod.repo
-
-# Add Microsoft repository key
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-
-# Update the list of products
-sudo zypper update
-
-# Install system level component and mssql-cli
-sudo zypper install libffi-devel
-sudo zypper install mssql-cli
-```
-
-
-## Fedora
-
-### Fedora
-
-#### Fedora 25
-
-```sh
-# Register the Microsoft RedHat repository
-sudo curl -o /etc/yum.repos.d/mssql-cli.repo https://packages.microsoft.com/config/rhel/7/prod.repo
-
-# Update the list of products
-sudo dnf update
-
-# Install mssql-cli
-sudo dnf install mssql-cli
-```
-
-#### Fedora 26
-```sh
-# Register the Microsoft RedHat repository
-sudo curl -o /etc/yum.repos.d/mssql-cli.repo https://packages.microsoft.com/config/rhel/7/prod.repo
-
-# Update the list of products
-sudo dnf update
-
-# Install mssql-cli
-sudo dnf install mssql-cli
-```

--- a/doc/release_guide.md
+++ b/doc/release_guide.md
@@ -1,21 +1,22 @@
-mssql-cli Release Guide
-========================================
-# Table of Contents
+# mssql-cli Release Guide
+
+## Table of Contents
 1. [Requirements](#requirements)
 2. [Creating a New Version](#creating-a-new-version)
 3. [Generating Release Files](#generating-release-files)
 4. [Publishing Release Files](#publishing-release-files)
-5. [Installing Specific Release Files from Azure Storage](#installing-specific-release-files-from-azure-storage)
+5. [Update Links in Installation Readme](#Update-Links-in-Installation-Readme)
+6. [Installing Specific Release Files from Azure Storage](#installing-specific-release-files-from-azure-storage)
 
 
-# Requirements
-## Installing Dependencies
+## Requirements
+### Installing Dependencies
 1.  Add `<clone_root>` to your PYTHONPATH environment variable:
-    #### Windows
+    ##### Windows
     ```
     set PYTHONPATH=<clone_root>;%PYTHONPATH%
     ```
-    #### OSX/Ubuntu (bash)
+    ##### OSX/Ubuntu (bash)
     ```
     export PYTHONPATH=<clone_root>:${PYTHONPATH}
     ```
@@ -23,7 +24,7 @@ mssql-cli Release Guide
     ```
     python <clone_root>/dev_setup.py
     ```
-## Azure Storage Account Configuration
+### Azure Storage Account Configuration
 1. The Azure Storage account needs a container named **daily**.
 
 2. A sub folder named **mssql-cli** under the previous container.
@@ -40,7 +41,7 @@ mssql-cli Release Guide
     export AZURE_STORAGE_CONNECTION_STRING='<connection_string>'
     ```
 
-# Creating a New Version
+## Creating a New Version
 The versioning format for `mssql-cli` uses the following naming scheme:
 
 	Versioning schema: {major}.{minor}.{patch}
@@ -56,20 +57,20 @@ Check-in changes after running `bumpversion` and **validating the build output f
 **Note**: bumpversion does not allow version bumping if your workspace has pending changes. This is to protect against any manual updates that may have been made which can lead to inconsistent versions across files. If you know what you are doing you can override this by appending `--allow-dirty` to the bumpversion command.
 
 
-# Generating Release Files
+## Generating Release Files
 The steps below outline how to create wheel and source distribution files to publish to Azure Storage, and eventually PyPI for official release.
 
-## Daily Release Configuration
+### Daily Release Configuration
 Release files are generated for daily release by default, as long as the `MSSQL_CLI_OFFICIAL_BUILD` environment variable is **not** set to `True`.
 
-## Official Release Configuration
+### Official Release Configuration
 The `MSSQL_CLI_OFFICIAL_BUILD` enviornment variable must be set to `True` before build files are created. Although this step can be completed locally, we recommend running production pipelines in Azure DevOps with the enviornment variable set for each run.
 
 If configured locally, instructions per OS are as follows:
 - **Windows**: `set MSSQL_CLI_OFFICIAL_BUILD=True`
 - **macOS/Linux**: `export MSSQL_CLI_OFFICIAL_BUILD=True`
 
-## Building Release Files
+### Building Release Files
 To build a release package with wheel and source distribution files for the current platform, run:
 ```
 python build.py build
@@ -78,19 +79,19 @@ Distribution files will be generated in `./dist/`. These files are eventually pu
 
 **Note:** source distribution files will only get created on macOS. This platform was arbitrarily chosen to prevent redundant copies of source distributions when `build` is run on each platform in Azure DevOps.
 
-# Publishing Release Files
+## Publishing Release Files
 The following instructions outline how to publish release files once generated n the `./dist/` folder.
 
-## Publishing Daily Builds to Azure Storage
+### Publishing Daily Builds to Azure Storage
 Publish build to daily storage account by calling:
 ```
 python release.py publish_daily
 ```
     
-## Publishing Official Builds
+### Publishing Official Builds
 The steps below outline how to build official builds and publish to PyPI.
 
-### Configuration with PyPI
+#### Configuration with PyPI
 A `.pypirc` configuration file must be created in order to publish to PyPI. Place in the following user directories.
 
 Examples for each OS:
@@ -115,7 +116,7 @@ username: sqlcli
 password: <Get Password from Azure Key Vault>
 ```
 
-### Test Publishing with TestPyPI
+#### Test Publishing with TestPyPI
 
 [TestPyPi](https://test.pypi.org) can be used to test distribution before going to production. To test publishing to TestPyPI, use the above `.pypirc` file and call:
 ```
@@ -124,7 +125,7 @@ twine upload --repository testpypi dist/*
 
 [Click here](https://packaging.python.org/guides/using-testpypi/) to view TestPyPI docs.
 
-### Publishing Official Release Files to PyPI
+#### Publishing Official Release Files to PyPI
 **Important: ensure that the build is uploaded from macOS.**
 
 Follow the instructions below to publish a new release to PyPI after official release build files have been published to Azure Storage:
@@ -139,7 +140,10 @@ Follow the instructions below to publish a new release to PyPI after official re
     python release.py publish_official
     ```
 
-# Installing Specific Release Files from Azure Storage
+## Update Links in Installation Readme
+Once a new official version has been published, please update the links in the [installation readme](https://github.com/dbcli/mssql-cli/tree/master/doc/installation).
+
+## Installing Specific Release Files from Azure Storage
 To test the installation a wheel or source distribution, execute the following from `<clone_root>`, replacing values for `<version>` and `<timestamp>`:
 ```
 pip install --no-index -i ./dist/mssql_cli-<version>.dev<timestamp>-py2.py3-none-win_amd64.whl


### PR DESCRIPTION
I've updated links to point at latest stable version number, rather than use 'dev-latest'.

Furthermore, all downloads now point to our daily storage. @pensivebrian please let me know if this is good practice.