### PR TITLE
Removed docker CP commands

### DIFF
--- a/build_scripts/debian/Dockerfile
+++ b/build_scripts/debian/Dockerfile
@@ -22,6 +22,4 @@ ADD . /Repos/mssql-cli
 WORKDIR /Repos/mssql-cli
 RUN build_scripts/debian/build.sh $(pwd)
 
-# Copy deb to root where DevOps copies package
 WORKDIR /
-RUN cp /Repos/debian_output/mssql-cli-dev-latest.deb .

--- a/build_scripts/rpm/Dockerfile
+++ b/build_scripts/rpm/Dockerfile
@@ -22,6 +22,4 @@ ADD . /Repos/mssql-cli
 WORKDIR /Repos/mssql-cli
 RUN build_scripts/rpm/build.sh $(pwd)
 
-# Copy rpm to root where DevOps copies package
 WORKDIR /
-RUN cp /Repos/rpm_output/mssql-cli-dev-latest.rpm .


### PR DESCRIPTION
The goal of this PR is to enable uploading of the dev timestamped packages for deb and rpm. Previously, we were uploading `mssql-cli-dev-latest.xxx` files.

Azure pipelines now use an updated `docker cp` command which copies the entire `debian_output` and `rpm_output` folders to the host machine, delete the `mssql-cli-dev-latest.xxx` file from the folder, and upload the remaining package to daily storage.