### PR TITLE
Stabilized db create for tests

### DIFF
--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 import socket
+import time
 import warnings
 from argparse import Namespace
 import mssqlcli.sqltoolsclient as sqltoolsclient
@@ -144,6 +145,9 @@ def check_create_db_status(db_name, client):
 
             if create_db_status != 'PROCESSING':
                 return create_db_status
+
+            # call sleep so db isn't overburdened with requrests
+            time.sleep(5)
 
     return 'FAILED'
 

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -99,6 +99,11 @@ def create_test_db():
     """
     options = create_mssql_cli_options(database='master')
     client = create_mssql_cli_client(options)
+
+    if not _is_client_db_on_cloud(client):
+        raise AssertionError("Create test DB must use SQL Azure. Please make sure the SQL" \
+                             "Server agent is in Azure and not on-prem.")
+
     local_machine_name = socket.gethostname().replace(
         '-', '_').replace('.', '_')
 
@@ -123,6 +128,16 @@ def create_test_db():
     # cleanup db just in case, then raise exception
     clean_up_test_db(test_db_name)
     raise AssertionError("DB creation failed.")
+
+def _is_client_db_on_cloud(client):
+    """
+    Checks if client is connected to Azure DB.
+    """
+    for rows, _, _, _, _ in client.execute_query("SELECT @@VERSION"):
+        if "microsoft sql azure" in rows[0][0].lower():
+            return True
+
+    return False
 
 def _check_create_db_status(db_name, client):
     """

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import os
 import socket
 import time
-import warnings
 from argparse import Namespace
 import mssqlcli.sqltoolsclient as sqltoolsclient
 import mssqlcli.mssqlcliclient as mssqlcliclient
@@ -157,11 +156,11 @@ def _check_create_db_status(db_name, client):
             state_desc = row[0][0]
             error_desc = row[0][1]
 
-            if state_desc != 'PROCESSING':
-                break
+        if state_desc != 'PROCESSING':
+            break
 
-            # call sleep so db isn't overburdened with requests
-            time.sleep(5)
+        # call sleep so db isn't overburdened with requests
+        time.sleep(5)
 
     return (state_desc, error_desc)
 

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -109,10 +109,6 @@ def create_test_db():
 
     try:
         for _, _, status, _, is_create_error in client.execute_query(query_db_create):
-            if is_create_error:
-                # break loop to assert db creation failure
-                raise AssertionError("Database creation failed: {}".format(status))
-
             if _is_client_db_on_cloud(client):
                 # retry logic is only supported for sql azure
                 create_db_status = _check_create_db_status(test_db_name, client)
@@ -121,6 +117,10 @@ def create_test_db():
                     # break loop to assert db creation failure
                     raise AssertionError("Database creation failed: retry logic for SQL " \
                                         "Azure DB was unsuccessful.")
+
+            if is_create_error:
+                # break loop to assert db creation failure
+                raise AssertionError("Database creation failed: {}".format(status))
 
         return test_db_name
 

--- a/tests/test_noninteractive_mode.py
+++ b/tests/test_noninteractive_mode.py
@@ -87,6 +87,8 @@ class TestNonInteractiveResults:
         """
         Tests query with multiple merges. Requires creation of temp db.
         """
+        db_name = None
+
         try:
             # create temporary db
             db_name = create_test_db()
@@ -99,7 +101,8 @@ class TestNonInteractiveResults:
                                                              .format(file_input, db_name))
             assert output_query == text_baseline
         finally:
-            clean_up_test_db(db_name)
+            if db_name:
+                clean_up_test_db(db_name)
 
     @classmethod
     @pytest.mark.timeout(60)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py27,py37,py38
 # We will build the sdist ourselves as we need to detect
 # what platform we are on and install the generated wheel
 # locally.


### PR DESCRIPTION
Closes #280.

This PR introduces retry logic to check the status of a db creation using `sys.dm_operation_status`.