### PR TITLE
Cast row_limit as integer

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -330,12 +330,15 @@ class MssqlCli(object):
         try:
             row_limit_int = int(row_limit)
         except ValueError:
-            click.secho(u'Error: --row-limit contains an invalid value as input. ' \
-                        u'Please use a positive integer.', fg='red')
+            click.secho(u'Error: row-limit has been set to an invalid value.\nPlease ' \
+                        u'specify a positive integer using the --row-limit command-line ' \
+                        u'argument or by setting row_limit in the config file.', fg='red')
             sys.exit(1)
         else:
             if row_limit_int < 0:
-                click.secho(u'Error: --row-limit cannot be negative.', fg='red')
+                click.secho(u'Error: row-limit cannot be negative.\nPlease ' \
+                            u'specify a positive integer using the --row-limit command-line ' \
+                            u'argument or by setting row_limit in the config file.', fg='red')
                 sys.exit(1)
             return row_limit_int
 

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -167,8 +167,7 @@ class MssqlCli(object):
             self.multiline_mode = c['main'].get('multi_line_mode', 'tsql')
             self.vi_mode = c['main'].as_bool('vi')
             self.prompt_format = options.prompt or c['main'].get('prompt', self.default_prompt)
-            self.row_limit = \
-                self._set_row_limit(options.row_limit or c['main'].as_int('row_limit'))
+            self.row_limit = options.row_limit
             self.min_num_menu_lines = c['main'].as_int('min_num_menu_lines')
             self.multiline_continuation_char = c['main']['multiline_continuation_char']
             self.syntax_style = c['main']['syntax_style']
@@ -209,14 +208,9 @@ class MssqlCli(object):
                              "specified.")
 
     def __del__(self):
-        """ Shut down sqltoolsservice if defined. """
-        try:
-            # try/except block needed if shutdown is invoked before sqltoolsclient is defined.
-            # example: invalid row-limit argument is passed.
-            if self.sqltoolsclient:
-                self.sqltoolsclient.shutdown()            
-        except AttributeError:
-            pass
+        # Shut-down sqltoolsservice
+        if self.sqltoolsclient:
+            self.sqltoolsclient.shutdown()
 
     # TODO: possibly use at a later date for expanded output file functionality
     # def write_to_file(self, pattern, **_):
@@ -320,27 +314,6 @@ class MssqlCli(object):
 
             editor_command = special.editor_command(text)
         return text
-
-    @staticmethod
-    def _set_row_limit(row_limit):
-        """
-        Validates row_limit option has valid integer
-        """
-
-        try:
-            row_limit_int = int(row_limit)
-        except ValueError:
-            click.secho(u'Error: row-limit has been set to an invalid value.\nPlease ' \
-                        u'specify a positive integer using the --row-limit command-line ' \
-                        u'argument or by setting row_limit in the config file.', fg='red')
-            sys.exit(1)
-        else:
-            if row_limit_int < 0:
-                click.secho(u'Error: row-limit cannot be negative.\nPlease ' \
-                            u'specify a positive integer using the --row-limit command-line ' \
-                            u'argument or by setting row_limit in the config file.', fg='red')
-                sys.exit(1)
-            return row_limit_int
 
     def _execute_interactive_command(self, text):
         """ Runs commands in the interactive CLI mode. """

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -167,11 +167,8 @@ class MssqlCli(object):
             self.multiline_mode = c['main'].get('multi_line_mode', 'tsql')
             self.vi_mode = c['main'].as_bool('vi')
             self.prompt_format = options.prompt or c['main'].get('prompt', self.default_prompt)
-            if options.row_limit is not None:
-                self.row_limit = options.row_limit
-            else:
-                self.row_limit = c['main'].as_int('row_limit')
-
+            self.row_limit = \
+                self._set_row_limit(options.row_limit or c['main'].as_int('row_limit'))
             self.min_num_menu_lines = c['main'].as_int('min_num_menu_lines')
             self.multiline_continuation_char = c['main']['multiline_continuation_char']
             self.syntax_style = c['main']['syntax_style']
@@ -212,9 +209,14 @@ class MssqlCli(object):
                              "specified.")
 
     def __del__(self):
-        # Shut-down sqltoolsservice
-        if self.sqltoolsclient:
-            self.sqltoolsclient.shutdown()
+        """ Shut down sqltoolsservice if defined. """
+        try:
+            # try/except block needed if shutdown is invoked before sqltoolsclient is defined.
+            # example: invalid row-limit argument is passed.
+            if self.sqltoolsclient:
+                self.sqltoolsclient.shutdown()            
+        except AttributeError:
+            pass
 
     # TODO: possibly use at a later date for expanded output file functionality
     # def write_to_file(self, pattern, **_):
@@ -318,6 +320,24 @@ class MssqlCli(object):
 
             editor_command = special.editor_command(text)
         return text
+
+    @staticmethod
+    def _set_row_limit(row_limit):
+        """
+        Validates row_limit option has valid integer
+        """
+
+        try:
+            row_limit_int = int(row_limit)
+        except ValueError:
+            click.secho(u'Error: --row-limit contains an invalid value as input. ' \
+                        u'Please use a positive integer.', fg='red')
+            sys.exit(1)
+        else:
+            if row_limit_int < 0:
+                click.secho(u'Error: --row-limit cannot be negative.', fg='red')
+                sys.exit(1)
+            return row_limit_int
 
     def _execute_interactive_command(self, text):
         """ Runs commands in the interactive CLI mode. """

--- a/mssqlcli/mssqlclioptionsparser.py
+++ b/mssqlcli/mssqlclioptionsparser.py
@@ -74,7 +74,7 @@ def create_parser():
         dest=u'row_limit',
         default=get_config()['main'].as_int('row_limit') or \
                 os.environ.get(MSSQL_CLI_ROW_LIMIT, None),
-        type=check_positive_int,
+        type=check_row_limit,
         metavar=u'',
         help=u'Set threshold for row limit prompt. Use 0 to disable prompt.')
 
@@ -192,9 +192,9 @@ def create_parser():
 
     return args_parser
 
-def check_positive_int(row_limit):
+def check_row_limit(row_limit):
     """
-    Validates row_limit option has valid integer
+    Validates row_limit option has valid positive integer
     """
 
     try:

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 import utility
-from mssqlcli.mssql_cli import MssqlCli
 from mssqlcli.util import is_command_valid
 from mssqltestutils import (
     create_mssql_cli,
@@ -81,52 +80,6 @@ class TestInteractiveModeInvalidRuns:
             mssqlcli.run()
             assert False
         except ValueError:
-            assert True
-        finally:
-            if mssqlcli is not None:
-                shutdown(mssqlcli)
-
-
-class TestInteractiveModeRowLimit:
-    # pylint: disable=protected-access
-
-    test_data_valid = [5, 0]
-    test_data_invalid = ['string!', -3]
-
-    @staticmethod
-    @pytest.mark.parametrize("row_limit", test_data_valid)
-    def test_valid_row_limit(row_limit):
-        """
-        Test valid value types for row limit argument
-        """
-        assert MssqlCli._set_row_limit(row_limit) == row_limit
-
-    @staticmethod
-    @pytest.mark.parametrize("row_limit", test_data_invalid)
-    def test_invalid_row_limit(row_limit):
-        """
-        Test invalid value types for row limit argument
-        """
-        try:
-            MssqlCli._set_row_limit(row_limit)
-        except SystemExit:
-            # mssqlcli class calls sys.exit(1) on invalid value
-            assert True
-        else:
-            assert False
-
-    @staticmethod
-    @pytest.mark.timeout(60)
-    def invalid_run(**options):
-        '''
-        Tests mssql-cli runs with invalid combination of properities set
-        '''
-        mssqlcli = None
-        try:
-            mssqlcli = create_mssql_cli(**options)
-            mssqlcli.run()
-            assert False
-        except SystemExit:
             assert True
         finally:
             if mssqlcli is not None:

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -2,7 +2,7 @@
 import unittest
 import pytest
 from mssqlcli.mssql_cli import MssqlCli
-from mssqlcli.mssqlclioptionsparser import check_positive_int
+from mssqlcli.mssqlclioptionsparser import check_row_limit
 from mssqltestutils import create_mssql_cli_options
 
 class RowLimitTests(unittest.TestCase):
@@ -62,7 +62,7 @@ class TestRowLimitArgs:
         """
         Test valid value types for row limit argument
         """
-        assert check_positive_int(row_limit) == row_limit
+        assert check_row_limit(row_limit) == row_limit
 
     @staticmethod
     @pytest.mark.parametrize("row_limit", test_data_invalid)
@@ -71,7 +71,7 @@ class TestRowLimitArgs:
         Test invalid value types for row limit argument
         """
         try:
-            check_positive_int(row_limit)
+            check_row_limit(row_limit)
         except SystemExit:
             # mssqlcli class calls sys.exit(1) on invalid value
             assert True

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access
 import unittest
+import pytest
 from mssqlcli.mssql_cli import MssqlCli
+from mssqlcli.mssqlclioptionsparser import check_positive_int
 from mssqltestutils import create_mssql_cli_options
 
 class RowLimitTests(unittest.TestCase):
@@ -43,3 +45,35 @@ class RowLimitTests(unittest.TestCase):
         result = cli._should_show_limit_prompt(stmt, ['row']*self.over_default)
         assert cli.row_limit == 0
         assert not result
+
+
+class TestRowLimitArgs:
+    """
+    Tests for valid row-limit arguments.
+    """
+    # pylint: disable=protected-access
+
+    test_data_valid = [5, 0]
+    test_data_invalid = ['string!', -3]
+
+    @staticmethod
+    @pytest.mark.parametrize("row_limit", test_data_valid)
+    def test_valid_row_limit(row_limit):
+        """
+        Test valid value types for row limit argument
+        """
+        assert check_positive_int(row_limit) == row_limit
+
+    @staticmethod
+    @pytest.mark.parametrize("row_limit", test_data_invalid)
+    def test_invalid_row_limit(row_limit):
+        """
+        Test invalid value types for row limit argument
+        """
+        try:
+            check_positive_int(row_limit)
+        except SystemExit:
+            # mssqlcli class calls sys.exit(1) on invalid value
+            assert True
+        else:
+            assert False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py27,py37,py38
 # We will build the sdist ourselves as we need to detect
 # what platform we are on and install the generated wheel
 # locally.


### PR DESCRIPTION
Fixes #444.

The `--row-limit` arg was breaking mssql-cli because our code attempted to use a number operator on a string. The fix requires casting the parsed option as an integer.

Notes:
* `row_limit` is validated in the `MssqlCli` constructor, which uses a new `_set_row_limit` method to validate a positive integer.
* `_set_row_limit` calls `sys.exit(1)` if an invalid value is provided.
* As a consequence to the above, we needed to catch an `AttributeException` in the `__del__` method because shutdown is called on an uninstantiated `sqltoolsclient`.
* Testing included to hopefully prevent issues like this in the future.