### PR TITLE
Updated links to privacy statements

### DIFF
--- a/doc/telemetry_guide.md
+++ b/doc/telemetry_guide.md
@@ -2,7 +2,7 @@
 
 By default, Microsoft collects anonymous usage data in order to improve the user experience. The usage data collected allows the team to prioritize features and bug fixes.
 
-Microsoft Privacy statement: https://privacy.microsoft.com/en-us/privacystatement
+Microsoft Privacy statement: https://go.microsoft.com/fwlink/?LinkId=521839
 
 ## Table of Contents
 1. [How do we anonymize the data?](#anonymize)

--- a/mssqlcli/main.py
+++ b/mssqlcli/main.py
@@ -24,7 +24,7 @@ The data is collected by Microsoft.
 
 Disable telemetry collection by setting environment variable MSSQL_CLI_TELEMETRY_OPTOUT to 'True' or '1'.
 
-Microsoft Privacy statement: https://privacy.microsoft.com/privacystatement
+Microsoft Privacy statement: https://go.microsoft.com/fwlink/?LinkId=521839
 """
 
 


### PR DESCRIPTION
Per privacy review, we've been instructed to update the links to our privacy statement.

Legal has instructed us to use https://go.microsoft.com/fwlink/?LinkId=521839, which updates the language based on user selection.