### PR TITLE
Created buffer size for logs

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -2,6 +2,7 @@ import datetime as dt
 import functools
 import itertools
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import sys
 import threading
@@ -243,7 +244,9 @@ class MssqlCli(object):
         if log_level.upper() == 'NONE':
             handler = logging.NullHandler()
         else:
-            handler = logging.FileHandler(os.path.expanduser(log_file), encoding='utf-8')
+            # creates a log buffer with max size of 100 MB and one backup file
+            handler = RotatingFileHandler(os.path.expanduser(log_file), encoding='utf-8',
+                                          maxBytes=10**8, backupCount=1)
 
         level_map = {'CRITICAL': logging.CRITICAL,
                      'ERROR': logging.ERROR,

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -244,9 +244,9 @@ class MssqlCli(object):
         if log_level.upper() == 'NONE':
             handler = logging.NullHandler()
         else:
-            # creates a log buffer with max size of 100 MB and one backup file
+            # creates a log buffer with max size of 20 MB and 5 backup files
             handler = RotatingFileHandler(os.path.expanduser(log_file), encoding='utf-8',
-                                          maxBytes=10**8, backupCount=1)
+                                          maxBytes=2*(10**7), backupCount=5)
 
         level_map = {'CRITICAL': logging.CRITICAL,
                      'ERROR': logging.ERROR,

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -246,7 +246,7 @@ class MssqlCli(object):
         else:
             # creates a log buffer with max size of 20 MB and 5 backup files
             handler = RotatingFileHandler(os.path.expanduser(log_file), encoding='utf-8',
-                                          maxBytes=2*(10**7), backupCount=5)
+                                          maxBytes=1024*1024*20, backupCount=5)
 
         level_map = {'CRITICAL': logging.CRITICAL,
                      'ERROR': logging.ERROR,


### PR DESCRIPTION
Closes #353.

This caps logs at 100 MB and adds one backup file to extend our buffer, per recommendation in Python's docs.

I think part of the problem with our logging is that it's incredible verbose—the file size jumps up a lot with limited use. I've created another issue to focus on decreasing the verboseness of our logs (#457).