### PR TITLE
Removed dev dependencies for deb and rpm

### DIFF
--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -101,6 +101,4 @@ cp -r $cli_debian_dir_tmp/* $source_dir/debian
 cd $source_dir
 dpkg-buildpackage -us -uc
 cp $deb_file $source_dir/../debian_output
-# Create a second copy for latest dev version to be used by homepage.
-cp $deb_file $source_dir/../debian_output/mssql-cli-dev-latest.deb
 echo "The archive has also been outputted to $source_dir/../debian_output"

--- a/build_scripts/rpm/build.sh
+++ b/build_scripts/rpm/build.sh
@@ -26,6 +26,4 @@ rpmbuild -v -bb --clean ${REPO_PATH}/build_scripts/rpm/mssql-cli.spec
 # Copy build artifact to output dir.
 mkdir ${REPO_PATH}/../rpm_output
 cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output
-# Create a second copy for latest dev version to be used by homepage.
-cp ~/rpmbuild/RPMS/x86_64/*.rpm ${REPO_PATH}/../rpm_output/mssql-cli-dev-latest.rpm
 echo "The archive has also been outputted to ${REPO_PATH}/../rpm_output"

--- a/build_scripts/rpm/mssql-cli.spec
+++ b/build_scripts/rpm/mssql-cli.spec
@@ -8,17 +8,17 @@
   %define dist .el7
 %endif
 
-%define name                   mssql-cli
-%define release                1%{?dist}
-%define time_stamp             %(date +%y%m%d%H%M)
-%define base_version           1.0.0
-%define python_dir             %{_builddir}/python_env
-%define python_build_archive   /root/python_build_archive
-%define python_build           /root/python_build
-%define python_url             https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz
-%define cli_lib_dir            %{_libdir}/mssql-cli
-%define repo_path              %{getenv:REPO_PATH}
-%define official_build         %{getenv:MSSQL_CLI_OFFICIAL_BUILD}
+%define name               mssql-cli
+%define release            1%{?dist}
+%define time_stamp         %(date +%y%m%d%H%M)
+%define base_version       1.0.0
+%define python_dir         %{_builddir}/python_env
+%define python_build_src   /root/python_build_src
+%define python_build       /root/python_build
+%define python_url         https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz
+%define cli_lib_dir        %{_libdir}/mssql-cli
+%define repo_path          %{getenv:REPO_PATH}
+%define official_build     %{getenv:MSSQL_CLI_OFFICIAL_BUILD}
 
 # the ',,' makes environment variable lower case in Bash 4+
 %if "%{official_build}" != "true"
@@ -50,14 +50,14 @@ Requires:       libunwind, libicu, less
 %prep
 # Clean previous build directory.
 rm -rf %{_builddir}/*
-rm -rf %{python_build_archive}
+rm -rf %{python_build_src}
 
 # Download, Extract Python3
-mkdir %{python_build_archive}
+mkdir %{python_build_src}
 python_archive=$(mktemp)
 wget https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz -qO $python_archive
 tar -xvzf $python_archive -C %{_builddir}
-tar -xvzf $python_archive -C %{python_build_archive}
+tar -xvzf $python_archive -C %{python_build_src}
 
 %build
 # clean any previous make files
@@ -69,7 +69,7 @@ make
 make install
 
 # A copy of Python is created for build dependencies only
-%{python_build_archive}/*/configure --srcdir %{python_build_archive}/* --prefix %{python_build}
+%{python_build_src}/*/configure --srcdir %{python_build_src}/* --prefix %{python_build}
 make
 make install
 


### PR DESCRIPTION
Changes for both deb and rpm build scripts:
- Compiles two different Python exe's instead of just one
- Downloads dev dependencies in one version
- Installs the built mssql-cli wheel in the other version

I've validated that both new packages work and only come installed with dependencies in setup.py.