### PR TITLE
Docker examples and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Read the section below to quickly get started with mssql-cli. Consult the [usage
 
 ### Install mssql-cli
 Platform-specific installation instructions are below:
-| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) |
-| - | - | - |
+| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/) |
+| - | - | - | - |
 
 Visit the [installation reference guide](https://github.com/dbcli/mssql-cli/tree/master/doc/installation) to view all supported releases and downloads.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read the section below to quickly get started with mssql-cli. Consult the [usage
 
 ### Install mssql-cli
 Platform-specific installation instructions are below:
-| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/) |
+| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/prod) |
 | - | - | - | - |
 
 Visit the [installation reference guide](https://github.com/dbcli/mssql-cli/tree/master/doc/installation) to view all supported releases and downloads.

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -4,8 +4,8 @@
 
 Select your platform for mssql-cli installation instructions:
 
-| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) |
-| - | - | - |
+| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/) |
+| - | - | - | - |
 
 
 ## Direct Downloads

--- a/doc/installation/README.md
+++ b/doc/installation/README.md
@@ -4,7 +4,7 @@
 
 Select your platform for mssql-cli installation instructions:
 
-| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/) |
+| [Windows](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/windows.md#windows-installation) | [macOS](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/macos.md#macos-installation) | [Linux](https://github.com/dbcli/mssql-cli/blob/master/doc/installation/linux.md) | [Docker](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/prod) |
 | - | - | - | - |
 
 

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -1,7 +1,7 @@
 # Linux Installation
 Stable installations of mssql-cli on Linux are hosted in the [Microsoft Linux Software Repository](https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software).
 
-mssql-cli supports the Linux distributions listed below. Docker instructions can be seen [here](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/).
+mssql-cli supports the Linux distributions listed below. Docker instructions can be seen [here](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/prod).
 
 [**Debian-based**](#Debian-based)
 - [**Ubuntu**](#Ubuntu)

--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -1,5 +1,7 @@
 # Linux Installation
-Stable installations of mssql-cli on Linux are hosted in the [Microsoft Linux Software Repository](https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software). mssql-cli supports the following Linux distributions:
+Stable installations of mssql-cli on Linux are hosted in the [Microsoft Linux Software Repository](https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software).
+
+mssql-cli supports the Linux distributions listed below. Docker instructions can be seen [here](https://github.com/dbcli/mssql-cli/blob/master/docker_environments/).
 
 [**Debian-based**](#Debian-based)
 - [**Ubuntu**](#Ubuntu)

--- a/docker_environments/README.md
+++ b/docker_environments/README.md
@@ -1,0 +1,64 @@
+# mssql-cli on Docker
+mssql-cli supports a variety of Docker environments. This article presents information for:
+1. Installing mssql-cli in your own Docker container.
+2. Automating build and run of multiple Docker containers for easier testing.
+
+## Dockerfile Examples
+The [prod](https://github.com/dbcli/mssql-cli/tree/master/docker_environments/prod/) folder contains example Dockerfiles for each supported Linux distribution.
+
+## Testing Docker Environments
+mssql-cli provides automated scripts for building and running multiple Docker containers. The automation works by:
+1. Running an initial script to build Docker containers for each Dockerfile in a specified folder.
+2. Running a secondary script to interactively run each built container with mssql-cli pre-installed. Exiting the container will automatically run the next Docker container.
+
+### Requirements for Automated Testing
+1. **Docker Desktop.** Install Docker Desktop from the [Docker website](https://www.docker.com/products/docker-desktop).
+2. **RedHat registry login.** For SQL Tools team members, please consult the team OneNote for using RHEL company credentials. Call `docker login registry.redhat.io` and log in with your credentials.
+
+### Building Docker Containers for Testing
+
+#### Set Environment Variables
+Consult the mssql-cli section under the 'Tooling Master Notebook' OneNote to obtain values for RedHat credentials:
+
+> Note: replace `export` with `set` if using Windows.
+
+```sh
+export MSSQL_CLI_PKG_DEB=<direct link to .deb package>
+export MSSQL_CLI_PKG_RPM=<direct link to .rpm package>
+export REDHAT_USERNAME=<RedHat username>
+export REDHAT_PASSWORD=<RedHat password>
+```
+
+#### Running Build Script
+From the `docker_environments` folder, run:
+```sh
+# Builds a Docker container for each Dockerfile in a specified folder.
+# For example: ./build_containers.sh $(pwd) testing_direct --no-cache
+./build_containers.sh $(pwd) <folder-name> --no-cache
+```
+
+The `testing_direct` folder should be used for testing builds hosted in the Azure daily storage account.
+
+### Automated Container Runs for Testing
+The `run_containers.sh` script will:
+1. Interactively run each built container from the `build_containers.sh` script.
+2. Allow for mssql-cli testing inside the interactive container.
+3. Upon `exit` will interactively run the next pre-built container.
+
+From the `docker_environments` folder, run:
+```sh
+# Runs each pre-built Docker container specified in a folder.
+# For example: ./run_containers.sh $(pwd) testing_direct
+./run_containers.sh $(pwd) <folder-name>
+```
+
+This will automatically run each built container in an interactive console. Simply call `mssql-cli` to test the installation.
+
+When you're done, exit mssql-cli and type `exit` to move on to the next container.
+
+#### Clearning Space After Testing
+Creating multiple Docker containers can take up substantial space on your drive. To clear space, call:
+```sh
+# WARNING: this command may remove unintended Docker containers, please use with caution.
+docker system prune
+```

--- a/docker_environments/build_containers.sh
+++ b/docker_environments/build_containers.sh
@@ -1,0 +1,49 @@
+# Creates docker containers for each supported Linux distribution
+
+if [ -z "$1" ]; then
+    echo "Argument should be path to local repo."
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    echo "Must specify folder name for Docker images. For example: 'linux=prod'."
+    exit 1
+else
+    docker_dir=$2
+fi
+
+if [ $3='--no-cache' ]; then
+    arg_no_cache='--no-cache'
+else
+    arg_no_cache=''
+fi
+
+# Exit script if environment variables are unset
+if [[ -z "${MSSQL_CLI_SERVER}" || -z "${MSSQL_CLI_DATABASE}" || \
+    -z "${MSSQL_CLI_USER}" || -z "${MSSQL_CLI_PASSWORD}" ]]; then
+    echo "Environment variables need to be set for server, database, user, and password."
+    exit 1
+fi
+
+local_repo=$1
+
+for dir in $local_repo/$docker_dir/*; do
+    dist_name=${dir##*/}
+    tag_name=mssqlcli:$dist_name
+
+    echo "BUILDING CONTAINER FOR: $dist_name\n"
+    
+    # build container
+    docker build \
+        --build-arg MSSQL_CLI_SERVER=${MSSQL_CLI_SERVER} \
+        --build-arg MSSQL_CLI_DATABASE=${MSSQL_CLI_DATABASE} \
+        --build-arg MSSQL_CLI_USER=${MSSQL_CLI_USER} \
+        --build-arg MSSQL_CLI_PASSWORD=${MSSQL_CLI_PASSWORD} \
+        --build-arg MSSQL_CLI_PKG_DEB=${MSSQL_CLI_PKG_DEB} \
+        --build-arg MSSQL_CLI_PKG_RPM=${MSSQL_CLI_PKG_RPM} \
+        --build-arg REDHAT_USERNAME=${REDHAT_USERNAME} \
+        --build-arg REDHAT_PASSWORD=${REDHAT_PASSWORD} \
+        -t $tag_name -f $dir/Dockerfile . $arg_no_cache
+
+    echo "\n\n"
+done

--- a/docker_environments/prod/README.md
+++ b/docker_environments/prod/README.md
@@ -1,0 +1,3 @@
+# mssql-cli Dockerfile Examples
+
+Each folder contains a Dockerfile which builds a container with mssql-cli installed in its respective Linux distribution.

--- a/docker_environments/prod/centos7/Dockerfile
+++ b/docker_environments/prod/centos7/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:7
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Installs dependencies
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y wget libicu libunwind less
+
+# Installs mssql-cli
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN curl -o /etc/yum.repos.d/mssql-cli.repo https://packages.microsoft.com/config/centos/7/prod.repo
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/centos8/Dockerfile
+++ b/docker_environments/prod/centos8/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:8
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Installs dependencies
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y wget libicu libunwind less
+
+# Installs mssql-cli
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN curl -o /etc/yum.repos.d/mssql-cli.repo https://packages.microsoft.com/config/centos/8/prod.repo
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/debian-jessie/Dockerfile
+++ b/docker_environments/prod/debian-jessie/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:8
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Install system components
+RUN apt-get update
+RUN apt-get -y install wget curl software-properties-common apt-transport-https
+
+# Import the public repository GPG keys
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+# Register the Microsoft Product feed
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/debian/8/prod jessie main" | tee /etc/apt/sources.list.d/mssql-cli.list
+
+# Update the list of products
+RUN apt-get update
+
+# Install mssql-cli
+RUN apt-get install -y mssql-cli
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/prod/debian-stretch/Dockerfile
+++ b/docker_environments/prod/debian-stretch/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:9
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Install system components
+RUN apt-get update
+RUN apt-get -y install wget curl software-properties-common apt-transport-https gnupg
+
+# Import the public repository GPG keys
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+# Register the Microsoft Product feed
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/debian/9/prod stretch main" | tee /etc/apt/sources.list.d/mssql-cli.list
+
+# Update the list of products
+RUN apt-get update
+
+# Install mssql-cli
+RUN apt-get install -y mssql-cli
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/prod/rhel7.0/Dockerfile
+++ b/docker_environments/prod/rhel7.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.redhat.io/rhel7.0
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+RUN yum install -y wget libicu libunwind less
+
+RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/rhel7.1/Dockerfile
+++ b/docker_environments/prod/rhel7.1/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.redhat.io/rhel7.1
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+RUN yum install -y wget libicu libunwind less
+
+RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/rhel7.2/Dockerfile
+++ b/docker_environments/prod/rhel7.2/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.redhat.io/rhel7.2
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+RUN yum install -y wget libicu libunwind less
+
+RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/rhel7.3/Dockerfile
+++ b/docker_environments/prod/rhel7.3/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.redhat.io/rhel7.3
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+RUN yum install -y wget libicu libunwind less
+
+RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/rhel7.4/Dockerfile
+++ b/docker_environments/prod/rhel7.4/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.redhat.io/rhel7.4
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+RUN yum install -y wget libicu libunwind less
+
+RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+RUN yum install -y mssql-cli

--- a/docker_environments/prod/ubuntu-bionic/Dockerfile
+++ b/docker_environments/prod/ubuntu-bionic/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs mssql-cli from Packages.Microsoft
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+# Use for pulling from prod channel
+RUN apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod
+
+RUN apt-get update
+RUN apt-get install -y mssql-cli
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/prod/ubuntu-trusty/Dockerfile
+++ b/docker_environments/prod/ubuntu-trusty/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:14.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs mssql-cli from Packages.Microsoft
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN apt-add-repository https://packages.microsoft.com/ubuntu/14.04/prod
+RUN apt-get update
+RUN apt-get install -y mssql-cli
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/prod/ubuntu-xenial/Dockerfile
+++ b/docker_environments/prod/ubuntu-xenial/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:16.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs mssql-cli from Packages.Microsoft
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN apt-add-repository https://packages.microsoft.com/ubuntu/16.04/prod
+RUN apt-get update
+RUN apt-get install -y mssql-cli
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/run_containers.sh
+++ b/docker_environments/run_containers.sh
@@ -1,0 +1,29 @@
+# Runs docker containers for each supported Linux distribution
+# Enables easier interactive mode testing
+
+if [ -z "$1" ]
+  then
+    echo "Argument should be path to local repo."
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    echo "Must specify folder name for Docker images. For example: 'prod'."
+    exit 1
+else
+    docker_dir=$2
+fi
+
+local_repo=$1
+
+for dir in $local_repo/$docker_dir/*; do
+    dist_name=${dir##*/}
+    tag_name=mssqlcli:$dist_name
+
+    echo "RUNNING CONTAINER FOR: $dist_name\n"
+
+    # run container
+    docker run -it $tag_name bash
+    
+    echo "\n\n"
+done

--- a/docker_environments/testing_direct/centos7/Dockerfile
+++ b/docker_environments/testing_direct/centos7/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:7
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Installs dependencies
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/centos8/Dockerfile
+++ b/docker_environments/testing_direct/centos8/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:8
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+# Installs dependencies
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/debian-jessie/Dockerfile
+++ b/docker_environments/testing_direct/debian-jessie/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:8
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_DEB
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget sudo curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs deb from arg
+RUN wget $MSSQL_CLI_PKG_DEB
+RUN dpkg -i ./mssql-cli_*.deb; exit 0
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/testing_direct/debian-stretch/Dockerfile
+++ b/docker_environments/testing_direct/debian-stretch/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:9
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_DEB
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs deb from arg
+RUN wget $MSSQL_CLI_PKG_DEB
+RUN dpkg -i ./mssql-cli_*.deb; exit 0
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/testing_direct/rhel7.0/Dockerfile
+++ b/docker_environments/testing_direct/rhel7.0/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.redhat.io/rhel7.0
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+
+# Installs dependencies
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/rhel7.1/Dockerfile
+++ b/docker_environments/testing_direct/rhel7.1/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.redhat.io/rhel7.1
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+
+# Installs dependencies
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/rhel7.2/Dockerfile
+++ b/docker_environments/testing_direct/rhel7.2/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.redhat.io/rhel7.2
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+
+# Installs dependencies
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/rhel7.3/Dockerfile
+++ b/docker_environments/testing_direct/rhel7.3/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.redhat.io/rhel7.3
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+
+# Installs dependencies
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/rhel7.4/Dockerfile
+++ b/docker_environments/testing_direct/rhel7.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.redhat.io/rhel7.4
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_RPM
+ARG REDHAT_USERNAME
+ARG REDHAT_PASSWORD
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD --auto-attach
+
+# Installs dependencies
+RUN yum install -y wget libicu libunwind less
+
+# Installs rpm from arg
+RUN wget $MSSQL_CLI_PKG_RPM
+RUN yum install -y mssql-cli-*.rpm

--- a/docker_environments/testing_direct/ubuntu-bionic/Dockerfile
+++ b/docker_environments/testing_direct/ubuntu-bionic/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_DEB
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget sudo curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs deb from arg
+RUN wget $MSSQL_CLI_PKG_DEB
+RUN dpkg -i ./mssql-cli_*.deb; exit 0
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/testing_direct/ubuntu-trusty/Dockerfile
+++ b/docker_environments/testing_direct/ubuntu-trusty/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:14.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_DEB
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget sudo curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs deb from arg
+RUN wget $MSSQL_CLI_PKG_DEB
+RUN dpkg -i ./mssql-cli_*.deb; exit 0
+
+# Installs missing requirements
+RUN apt-get install -y -f

--- a/docker_environments/testing_direct/ubuntu-xenial/Dockerfile
+++ b/docker_environments/testing_direct/ubuntu-xenial/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:16.04
+
+ARG MSSQL_CLI_SERVER
+ARG MSSQL_CLI_DATABASE
+ARG MSSQL_CLI_USER
+ARG MSSQL_CLI_PASSWORD
+ARG MSSQL_CLI_PKG_DEB
+
+ENV MSSQL_CLI_SERVER=$MSSQL_CLI_SERVER
+ENV MSSQL_CLI_DATABASE=$MSSQL_CLI_DATABASE
+ENV MSSQL_CLI_USER=$MSSQL_CLI_USER
+ENV MSSQL_CLI_PASSWORD=$MSSQL_CLI_PASSWORD
+
+RUN apt-get update
+RUN apt-get -y install wget sudo curl
+RUN apt-get -y install software-properties-common
+RUN apt-get -y install apt-transport-https
+
+# Installs deb from arg
+RUN wget $MSSQL_CLI_PKG_DEB
+RUN dpkg -i ./mssql-cli_*.deb; exit 0
+
+# Installs missing requirements
+RUN apt-get install -y -f


### PR DESCRIPTION
This PR accomplishes two things:
1. Provides examples of Dockerfiles for customers to build mssql-cli in their own containers.
2. Creates an automated process for building and running many Docker containers for easier testing.

I recommend examining the newly proposed `docker_enviornments` folder, previewed [here](https://github.com/dbcli/mssql-cli/tree/ellbosch/linux-testing/docker_environments), instead of reading through the diff. Changes include:
* [`build_containers.sh`](https://github.com/dbcli/mssql-cli/blob/ellbosch/linux-testing/docker_environments/build_containers.sh): a script which builds Docker containers for each Dockerfile specified in a folder.
* [`run_containers.sh`](https://github.com/dbcli/mssql-cli/blob/ellbosch/linux-testing/docker_environments/run_containers.sh): a script which runs each Docker container consecutively. This enables for a simplified testing process so that each Docker container will not need to be built and run individually.
* A [prod](https://github.com/dbcli/mssql-cli/tree/ellbosch/linux-testing/docker_environments/prod) folder providing Dockerfiles which pull mssql-cli from Packages.Microsoft. Customers are intended to use this.
* A [testing_direct](https://github.com/dbcli/mssql-cli/tree/ellbosch/linux-testing/docker_environments/testing_direct) folder with Dockerfiles that download mssql-cli using a provided link. This is intended to use for testing stable builds.
* Doc changes, including a new [readme](https://github.com/dbcli/mssql-cli/blob/ellbosch/linux-testing/docker_environments/README.md) for Docker.