### PR TITLE
Added UTF-8 encoding on Python 2

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -16,6 +16,7 @@ from cli_helpers.tabular_output.preprocessors import (align_decimals,
                                                       format_numbers)
 import humanize
 import click
+import six
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle
 from prompt_toolkit.completion import DynamicCompleter, ThreadedCompleter
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
@@ -368,8 +369,12 @@ class MssqlCli(object):
 
     def execute_query(self, text):
         """ Processes a query string and outputs to file or terminal """
+        if six.PY2:
+            # text needs to be encoded to utf-8 on Python 2
+            text = str(text.encode('utf-8'))
+        else:
+            text = str(text)
 
-        text = str(text)
         if self.interactive_mode:
             output = self._execute_interactive_command(text)
         else:

--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -46,7 +46,7 @@ from mssqlcli.mssqltoolbar import create_toolbar_tokens_func
 from mssqlcli.sqltoolsclient import SqlToolsClient
 from mssqlcli.packages import special
 from mssqlcli.mssqlbuffer import mssql_is_multiline
-from mssqlcli.util import is_command_valid
+from mssqlcli.util import is_command_valid, encode
 import mssqlcli.localized_strings as localized
 
 # Query tuples are used for maintaining history
@@ -371,7 +371,7 @@ class MssqlCli(object):
         """ Processes a query string and outputs to file or terminal """
         if six.PY2:
             # text needs to be encoded to utf-8 on Python 2
-            text = str(text.encode('utf-8'))
+            text = encode(text)
         else:
             text = str(text)
 

--- a/mssqlcli/util.py
+++ b/mssqlcli/util.py
@@ -4,7 +4,7 @@ import subprocess
 def encode(s):
     try:
         return s.encode('utf-8')
-    except (AttributeError, SyntaxError):
+    except (AttributeError, SyntaxError, UnicodeDecodeError):
         pass
     return s
 


### PR DESCRIPTION
Fixes bug that breaks interactive queries when international strings are used in Python 2.