### PR TITLE
Added script for new hire PR submission

### DIFF
--- a/employee_registry.txt
+++ b/employee_registry.txt
@@ -1,1 +1,1 @@
-elbosc was here!		2020-04-30
+elbosc was here!                                  2020-04-30

--- a/employee_registry.txt
+++ b/employee_registry.txt
@@ -1,0 +1,1 @@
+elbosc was here!		2020-04-30

--- a/new_hire.py
+++ b/new_hire.py
@@ -1,0 +1,23 @@
+# Designed for new hires to complete their first PR.
+# Writes to 'employee_registry.txt' by calling `python new_hire.py <alias>`
+
+from datetime import date
+import os
+import sys
+import click
+from utility import ROOT_DIR
+
+def register_alias(alias):
+    """
+    Appends text to 'employee_registry.txt'
+    """
+    with open(os.path.join(ROOT_DIR, 'employee_registry.txt'), 'a') as f:
+        f.write('{} was here!\t\t{}\n'.format(alias, date.today()))
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        click.secho("`new_hire.py` takes one string as an argument. "
+                    "Please provide your alias surrounded in strings, "
+                    "i.e. \"elbosc\".", err=True)
+    else:
+        register_alias(sys.argv[1])

--- a/new_hire.py
+++ b/new_hire.py
@@ -12,7 +12,7 @@ def register_alias(alias):
     Appends text to 'employee_registry.txt'
     """
     with open(os.path.join(ROOT_DIR, 'employee_registry.txt'), 'a') as f:
-        f.write('{} was here!\t\t{}\n'.format(alias, date.today()))
+        f.write('{0} was here!\t{1}\n'.format(alias, date.today()).expandtabs(50))
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:


### PR DESCRIPTION
The new-hire notebook will teach employees how to use the `new_hire.py` script to submit their first PR. When the script is called, it will append their alias and timestamp to the `employee_registry.txt` file.

Example call for new hire: `new_hire.py <alias>`