### PR TITLE
Add possibility to style the individual prompt placeholders

### DIFF
--- a/mssqlcli/mssql_cli.py
+++ b/mssqlcli/mssql_cli.py
@@ -16,6 +16,7 @@ from cli_helpers.tabular_output.preprocessors import (align_decimals,
                                                       format_numbers)
 import humanize
 import click
+from prompt_toolkit import HTML
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle
 from prompt_toolkit.completion import DynamicCompleter, ThreadedCompleter
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
@@ -457,8 +458,7 @@ class MssqlCli(object):
         """
 
         def get_message():
-            prompt = self.get_prompt(self.prompt_format)
-            return [(u'class:prompt', prompt)]
+            return self.get_prompt(self.prompt_format)
 
         def get_continuation(width, line_number, is_soft_wrap):
             """
@@ -709,13 +709,13 @@ class MssqlCli(object):
                 Document(text=text, cursor_position=cursor_position), None)
 
     def get_prompt(self, string):
-        string = string.replace('\\t', self.now.strftime('%x %X'))
-        string = string.replace('\\u', self.mssqlcliclient_main.user_name or '(none)')
-        string = string.replace('\\h', self.mssqlcliclient_main.prompt_host or '(none)')
-        string = string.replace('\\d', self.mssqlcliclient_main.connected_database or '(none)')
-        string = string.replace('\\p', str(self.mssqlcliclient_main.prompt_port) or '(none)')
+        string = string.replace('\\t', "<prompt.datetime>%s</prompt.datetime>" % self.now.strftime('%x %X'))
+        string = string.replace('\\u', "<prompt.username>%s</prompt.username>" % self.mssqlcliclient_main.user_name or '(none)')
+        string = string.replace('\\h', "<prompt.hostname>%s</prompt.hostname>" % self.mssqlcliclient_main.prompt_host or '(none)')
+        string = string.replace('\\d', "<prompt.database>%s</prompt.database>" % self.mssqlcliclient_main.connected_database or '(none)')
+        string = string.replace('\\p', "<prompt.port>%s</prompt.port>" % str(self.mssqlcliclient_main.prompt_port) or '(none)')
         string = string.replace('\\n', "\n")
-        return string
+        return HTML("<prompt.default>%s</prompt.default>" % string)
 
     def get_last_query(self):
         """Get the last query executed or None."""

--- a/mssqlcli/mssqlclirc
+++ b/mssqlcli/mssqlclirc
@@ -145,6 +145,14 @@ arg-toolbar.text = 'nobold'
 bottom-toolbar.transaction.valid = 'bg:#222222 #00ff5f bold'
 bottom-toolbar.transaction.failed = 'bg:#222222 #ff005f bold'
 
+# style classes for the prompt
+# prompt.default = 'bg:#000000 #FFFFFF'
+# prompt.datetime = 'bg:#000000 #FFFFFF'
+# prompt.username = 'bg:#000000 #FFFFFF'
+# prompt.hostname = 'bg:#000000 #FFFFFF'
+# prompt.database = 'bg:#000000 #FFFFFF'
+# prompt.port = 'bg:#000000 #FFFFFF'
+
 # style classes for colored table output
 output.header = "#00ff5f bold"
 output.odd-row = ""

--- a/mssqlcli/mssqlstyle.py
+++ b/mssqlcli/mssqlstyle.py
@@ -36,12 +36,6 @@ TOKEN_TO_PROMPT_STYLE = {
     Token.Output.Header: 'output.header',
     Token.Output.OddRow: 'output.odd-row',
     Token.Output.EvenRow: 'output.even-row',
-    Token.Prompt.Default: 'prompt.default',
-    Token.Prompt.Datetime: 'prompt.datetime',
-    Token.Prompt.Username: 'prompt.username',
-    Token.Prompt.Hostname: 'prompt.hostname',
-    Token.Prompt.Database: 'prompt.database',
-    Token.Prompt.Port: 'prompt.port',
 }
 
 # reverse dict for cli_helpers, because they still expect Pygments tokens.

--- a/mssqlcli/mssqlstyle.py
+++ b/mssqlcli/mssqlstyle.py
@@ -36,6 +36,12 @@ TOKEN_TO_PROMPT_STYLE = {
     Token.Output.Header: 'output.header',
     Token.Output.OddRow: 'output.odd-row',
     Token.Output.EvenRow: 'output.even-row',
+    Token.Prompt.Default: 'prompt.default',
+    Token.Prompt.Datetime: 'prompt.datetime',
+    Token.Prompt.Username: 'prompt.username',
+    Token.Prompt.Hostname: 'prompt.hostname',
+    Token.Prompt.Database: 'prompt.database',
+    Token.Prompt.Port: 'prompt.port',
 }
 
 # reverse dict for cli_helpers, because they still expect Pygments tokens.


### PR DESCRIPTION
Added the possibility to style the individual prompt placeholders, since I use a few of the placeholders but want the hostname to stand out a bit more.
Uses the prompt_toolkit's HTML() method, as splitting the prompt into a list of tuples seemed overkill.

Ideally I wanted to be able to style the prompt based on a regex or some sort of string matching, so that I could style it as red when I am querying a production database for example, just as a hint not to do anything stupid :)
... but I went for the easier option.