### PR TITLE
Require enum34 only for Python versions before 3.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 applicationinsights >= 0.11.1
 argparse >= 1.2.1
-enum34 >= 1.1.6
+enum34 >= 1.1.6 ; python_version < '3.4'
 future >= 0.16.0
 setuptools >= 36.0.1
 wheel >= 0.29.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requirements = [
     'applicationinsights>=0.11.1',
     'future>=0.16.0',
     'wheel>=0.29.0',
-    'enum34>=1.1.6'
+    'enum34>=1.1.6;python_version<"3.4"'
 ]
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
enum34 appears to be a potential source of problems when installed in
environments using Python 3.4 or later [0, 1]. Apparently enum34
1.1.8 was able to avoid these issues, but a regression was introduced in
1.1.9 and is still present in the most recent release \[2].

This commit loosens the requirement on enum34 so that it is only
installed if Python 3.3 or older is used.

This particular solution requires setuptools v36.2 or newer \[3]. If
older versions of setuptools need to be supported, then the requirements
can be put into an extras_require clause [4, 5].

\[0]: https://github.com/python-poetry/poetry/issues/1122
\[1]: https://github.com/iterative/dvc/issues/1995
\[2]: https://web.archive.org/web/20200621215937/https://bitbucket.org/stoneleaf/enum34/issues/31/make-the-install-a-noop-on-python36
\[3]: https://setuptools.readthedocs.io/en/latest/history.html#v36-2-0
\[4]: https://github.com/robshakir/pyangbind/issues/232#issuecomment-437987496
\[5]: https://gitlab.com/pycqa/flake8/-/merge_requests/191/diffs