### PR TITLE
Re-enable support for Python 2.7 and Python 3.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,10 +16,12 @@ docutils >= 0.13.1
 azure-storage == 0.36.0
 click >= 4.1, < 7.1
 Pygments >= 2.0
-prompt_toolkit >= 2.0.6 , < 4.0.0
+prompt_toolkit >= 2.0.6 , < 4.0.0 ; python_version > '2.7'
+prompt_toolkit >= 2.0.6 , < 3.0.0 ; python_version <= '2.7'
 sqlparse >= 0.3.0,<0.5
 configobj >= 5.0.6
 humanize >= 0.5.1
-cli_helpers[styles] >= 2.0.0
-mock>=1.0.1
+cli_helpers[styles] >= 2.0.0 ; python_version > '2.7'
+cli_helpers < 1.2.0 ; python_version <= '2.7'
+mock>=1.0.1 
 polib>=1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 applicationinsights >= 0.11.1
-enum34 >= 1.1.6
+enum34 >= 1.1.6 ; python_version < '3.4'
 future >= 0.16.0
 setuptools >= 36.0.1
 wheel >= 0.29.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requirements = [
     'applicationinsights>=0.11.1',
     'future>=0.16.0',
     'wheel>=0.29.0',
-    'enum34>=1.1.6'
+    'enum34>=1.1.6;python_version<"3.4"'
 ]
 
 with open("README.md", "r") as fh:
@@ -59,7 +59,6 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=install_requirements,
     include_package_data=True,
-    python_requires=">=3.6",
     scripts=[
         'mssql-cli.bat',
         'mssql-cli'
@@ -69,7 +68,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_timestamped_version(ver):
 install_requirements = [
     'click >= 4.1,<7.1',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased.
-    'prompt_toolkit>=2.0.6,<4.0.0;python_version>"2.7",
+    'prompt_toolkit>=2.0.6,<4.0.0;python_version>"2.7"',
     'prompt_toolkit>=2.0.6,<3.0.0;python_version<="2.7"',
     'sqlparse >=0.3.0,<0.5',
     'configobj >= 5.0.6',

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,13 @@ def get_timestamped_version(ver):
 install_requirements = [
     'click >= 4.1,<7.1',
     'Pygments >= 2.0',  # Pygments has to be Capitalcased.
-    'prompt_toolkit>=2.0.6,<4.0.0',
+    'prompt_toolkit>=2.0.6,<4.0.0;python_version>"2.7",
+    'prompt_toolkit>=2.0.6,<3.0.0;python_version<="2.7"',
     'sqlparse >=0.3.0,<0.5',
     'configobj >= 5.0.6',
     'humanize >= 0.5.1',
-    'cli_helpers[styles] >= 2.0.0',
+    'cli_helpers[styles] >= 2.0.0;python_version>"2.7"',
+    'cli_helpers < 1.2.0;python_version<="2.7"',
     'applicationinsights>=0.11.1',
     'future>=0.16.0',
     'wheel>=0.29.0',

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -23,7 +23,7 @@ test_queries = [
 
 # Ignore python 2.X which has a different baseline
 if (sys.version_info > (3, 0)):
-    test_queries["SELECT REPLICATE(CAST('X,' AS VARCHAR(MAX)), 1024)"] = 'col_wide.txt'
+    test_queries.append(("SELECT REPLICATE(CAST('X,' AS VARCHAR(MAX)), 1024)", 'col_wide.txt'))
 
 def create_mssql_cli(**non_default_options):
     mssqlcli_options = create_mssql_cli_options(**non_default_options)

--- a/tests/mssqltestutils.py
+++ b/tests/mssqltestutils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 import socket
+import sys
 import time
 from argparse import Namespace
 import mssqlcli.sqltoolsclient as sqltoolsclient
@@ -17,9 +18,12 @@ _BASELINE_DIR = os.path.dirname(os.path.abspath(__file__))
 test_queries = [
     ("SELECT 1", 'small.txt'),
     ("SELECT 1; SELECT 2;", 'multiple.txt'),
-    ("SELECT %s" % ('x' * 250), 'col_too_wide.txt'),
-    ("SELECT REPLICATE(CAST('X,' AS VARCHAR(MAX)), 1024)", 'col_wide.txt')
+    ("SELECT %s" % ('x' * 250), 'col_too_wide.txt')
 ]
+
+# Ignore python 2.X which has a different baseline
+if (sys.version_info > (3, 0)):
+    test_queries["SELECT REPLICATE(CAST('X,' AS VARCHAR(MAX)), 1024)"] = 'col_wide.txt'
 
 def create_mssql_cli(**non_default_options):
     mssqlcli_options = create_mssql_cli_options(**non_default_options)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py27,py35,py36,py37,py38,py39
 # We will build the sdist ourselves as we need to detect
 # what platform we are on and install the generated wheel
 # locally.


### PR DESCRIPTION
Re-enabling support for Python 2.7 and Python 3.5.