### PR TITLE
Update linux.md

### DIFF
--- a/doc/installation/linux.md
+++ b/doc/installation/linux.md
@@ -116,7 +116,7 @@ To uninstall mssql-cli, call `sudo apt-get remove mssql-cli`.
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # Register the Microsoft product feed
-curl https://packages.microsoft.com/config/centos/7/prod.repo > /etc/yum.repos.d/msprod.repo
+sudo bash -c "curl https://packages.microsoft.com/config/centos/7/prod.repo > /etc/yum.repos.d/msprod.repo"
 
 # Install dependencies and mssql-cli
 sudo yum install libunwind
@@ -129,7 +129,7 @@ sudo yum install mssql-cli
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # Register the Microsoft product feed
-curl https://packages.microsoft.com/config/centos/8/prod.repo > /etc/yum.repos.d/msprod.repo
+sudo bash -c "curl https://packages.microsoft.com/config/centos/8/prod.repo > /etc/yum.repos.d/msprod.repo"
 
 # Install dependencies and mssql-cli
 sudo yum install libunwind


### PR DESCRIPTION
Privilege elevation only applies to the curl process itself, not to the parent shell, and therefore not to the redirection.  It's better to do the redirection within the child shell itself, especially for an easy cut/paste.