### PR TITLE
[documentation] add docs on port configuration

### DIFF
--- a/doc/usage_guide.md
+++ b/doc/usage_guide.md
@@ -78,6 +78,12 @@ Connect to a server, a specific database, and with a username. -S -d and -U are 
 mssql-cli -S localhost -d AdventureWorks -U sa
 ```
 
+If the server is using a nonstandard port (1433) you can specify a port via the following invocation:
+
+```bash
+mssql-cli -S "localhost,42069" -d AdventureWorks -U sa
+```
+
 ### Exit mssql-cli 
 Press **Ctrl+D** or type `quit`.
 


### PR DESCRIPTION
This PR updates the `usage_guide.md` documentation by adding an example for port configuration. As a non SQLServer user I was unaware of the convention of using `HOST,PORT`. Without a CLI flag for port it was non obvious to me that a comma in the DB_HOST param was what was expected. [Looking at the source here](https://github.com/dbcli/mssql-cli/blob/53a7a8a35193b1d2c8c8d85a2cdd7a4c3e3e7409/mssqlcli/mssqlcliclient.py#L27-L32) revealed the answer.

In the future perhaps supporting a `-O --port` argument would be useful, happy to submit a PR if desired.

Newline as added at the end of the file as well.