### PR TITLE
changed command "python" to "python3"

### DIFF
--- a/mssql-cli
+++ b/mssql-cli
@@ -13,4 +13,4 @@ if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=UTF-8; fi
 
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 
-python -m mssqlcli.main "$@"
+python3 -m mssqlcli.main "$@"


### PR DESCRIPTION
I got error in my ubuntu machine running mssql-cli command gives me error of python command not found whereas in my machine python3 was installed, and when I changed the script to python3, it ran successfully.