### PR TITLE
feat: macos m1

### DIFF
--- a/mssqlcli/mssqltoolsservice/externals.py
+++ b/mssqlcli/mssqltoolsservice/externals.py
@@ -10,7 +10,7 @@ import utility
 
 install_aliases()
 
-SQLTOOLSSERVICE_RELEASE = "v3.0.0-release.72"
+SQLTOOLSSERVICE_RELEASE = "4.4.0.7"
 
 SQLTOOLSSERVICE_BASE = os.path.join(utility.ROOT_DIR, 'sqltoolsservice/')
 
@@ -20,6 +20,8 @@ SUPPORTED_PLATFORMS = {
                          'Microsoft.SqlTools.ServiceLayer-rhel-x64-netcoreapp3.1.tar.gz',
     'macosx_10_11_intel': SQLTOOLSSERVICE_BASE + 'macosx_10_11_intel/' +
                           'Microsoft.SqlTools.ServiceLayer-osx-x64-netcoreapp3.1.tar.gz',
+    'macos_m1': SQLTOOLSSERVICE_BASE + 'macos_m1/' +
+                          'Microsoft.SqlTools.ServiceLayer-osx-arm64-net6.0.tar.gz',
     'win_amd64': SQLTOOLSSERVICE_BASE + 'win_amd64/' +
                  'Microsoft.SqlTools.ServiceLayer-win-x64-netcoreapp3.1.zip',
     'win32': SQLTOOLSSERVICE_BASE + 'win32/' +
@@ -53,7 +55,7 @@ def copy_sqltoolsservice(platform):
     if not platform or platform not in SUPPORTED_PLATFORMS:
         print('{} is not supported.'.format(platform))
         print('Please provide a valid platform flag.' +
-              '[win32, win_amd64, manylinux1_x86_64, macosx_10_11_intel]')
+              '[win32, win_amd64, manylinux1_x86_64, macosx_10_11_intel, macos_m1]')
         sys.exit(1)
 
     copy_file_path = SUPPORTED_PLATFORMS[platform]

--- a/utility.py
+++ b/utility.py
@@ -68,6 +68,7 @@ def get_current_platform():
     """
     system = platform.system()
     arch = platform.architecture()[0]
+    processor = platform.processor()
 
     run_time_id = None
     if system == 'Windows':
@@ -76,7 +77,10 @@ def get_current_platform():
         elif arch == '64bit':
             run_time_id = 'win_amd64'
     elif system == 'Darwin':
-        run_time_id = 'macosx_10_11_intel'
+        if processor == 'arm':
+            run_time_id = 'macos_m1'
+        elif processor == 'amd':
+            run_time_id = 'macosx_10_11_intel'
     elif system == 'Linux':
         run_time_id = 'manylinux1_x86_64'
 
@@ -94,7 +98,7 @@ def copy_current_platform_mssqltoolsservice():
     if current_platform:
         mssqltoolsservice.copy_sqltoolsservice(current_platform)
     else:
-        print("This platform: {} does not support mssqltoolsservice.".format(platform.system()))
+        print("This platform: {},{},{} does not support mssqltoolsservice.".format(platform.system(), platform.architecture()[0], platform.processor()))
 
 
 def random_str(size=12, chars=string.ascii_uppercase + string.digits):


### PR DESCRIPTION
as mentioned https://github.com/dbcli/mssql-cli/issues/537 this will not build on M1. with these changes it does, but it fails while trying to connect. probably something that needs to be updated with the version bump (needed to bump to a version with arm64 release of sqltools)

I built it with:
```bash
python dev_setup.py
python build.py build
```